### PR TITLE
Initialises repository with settings and docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,114 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.vscode
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# macOS
+.DS_Store
+._*
+
+# PyCharm
+*.iml
+
+# reStructuredText preview
+README.html
+
+.idea
+out.java
+out/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-## AWS Cloudformation Rpdk Java Plugin
+## AWS CloudFormation Resource Provider Java Plugin
 
-The CloudFormation Provider Development Toolkit Java Plugin allows you to autogenerate java code based on an input schema.
 
-## License
+The CloudFormation Resource Provider Development Kit (RPDK) allows you to author your own resource providers that can be used by CloudFormation.
 
-This library is licensed under the Apache 2.0 License. 
+This plugin library helps to provide runtime bindings for the execution of your providers by CloudFormation. 
+
+License
+-------
+
+This library is licensed under the Apache 2.0 License.


### PR DESCRIPTION
Using files based on same from aws-cloudformation-rpdk repo. I know this also includes Python-specific ignores in a Java repository but I'm fine with that. Happy to be argued with.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
