### PR TITLE
Don't shade jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,24 +76,4 @@
         </dependency>
 
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Don't shade the jar produced by Maven. Shading includes all dependencies in one fat jar. As far as I can see, we don't want to do this if we are including the Java plugin in the RPDK build process, as Maven will sort out the dependencies via the `pom.xml`s, and only the last jar in the build process should be shaded. I'm not 100% sure though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
