### PR TITLE
Removed unnecessary compile build phase

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,4 +2,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - mvn clean compile package
+      - mvn clean package


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removed compile from build command. http://maven.apache.org/guides/getting-started/maven-in-five-minutes.html

From above link: "When a phase is given, Maven will execute every phase in the sequence up to and including the one defined." So, since `compile` and`package` are both phases and `package` is after `compile` in the build lifecycle, calling `package` implicitly calls `compile`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
