### PR TITLE
Created Provider<T> for AWS SDK Clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>guice</artifactId>
             <version>4.2.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.inject.extensions/guice-assistedinject -->
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-assistedinject</artifactId>
+            <version>4.2.1</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/aws/cfn/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/LambdaWrapper.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.aws.cfn.exceptions.TerminalException;
+import com.aws.cfn.injection.LambdaModule;
 import com.aws.cfn.metrics.MetricsPublisher;
 import com.aws.cfn.proxy.CallbackAdapter;
 import com.aws.cfn.proxy.HandlerRequest;

--- a/src/main/java/com/aws/cfn/injection/AmazonCloudFormationProvider.java
+++ b/src/main/java/com/aws/cfn/injection/AmazonCloudFormationProvider.java
@@ -1,0 +1,20 @@
+package com.aws.cfn.injection;
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder;
+import com.google.inject.Provider;
+
+public class AmazonCloudFormationProvider implements Provider<AmazonCloudFormation> {
+
+    @Override
+    public AmazonCloudFormation get() {
+         final EndpointConfiguration endpointConfiguration = new EndpointConfiguration(
+            "https://stackbuilder.us-west-2.amazonaws.com",
+        "us-west-2");
+
+        return AmazonCloudFormationClientBuilder.standard()
+            .withEndpointConfiguration(endpointConfiguration)
+            .build();
+    }
+}

--- a/src/main/java/com/aws/cfn/injection/AmazonCloudWatchEventsProvider.java
+++ b/src/main/java/com/aws/cfn/injection/AmazonCloudWatchEventsProvider.java
@@ -1,0 +1,14 @@
+package com.aws.cfn.injection;
+
+import com.amazonaws.services.cloudwatchevents.AmazonCloudWatchEvents;
+import com.amazonaws.services.cloudwatchevents.AmazonCloudWatchEventsClientBuilder;
+import com.google.inject.Provider;
+
+public class AmazonCloudWatchEventsProvider implements Provider<AmazonCloudWatchEvents> {
+
+    @Override
+    public AmazonCloudWatchEvents get() {
+        return AmazonCloudWatchEventsClientBuilder.standard()
+            .build();
+    }
+}

--- a/src/main/java/com/aws/cfn/injection/AmazonCloudWatchProvider.java
+++ b/src/main/java/com/aws/cfn/injection/AmazonCloudWatchProvider.java
@@ -1,0 +1,14 @@
+package com.aws.cfn.injection;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.google.inject.Provider;
+
+public class AmazonCloudWatchProvider implements Provider<AmazonCloudWatch> {
+
+    @Override
+    public AmazonCloudWatch get() {
+        return AmazonCloudWatchClientBuilder.standard()
+            .build();
+    }
+}

--- a/src/main/java/com/aws/cfn/injection/LambdaModule.java
+++ b/src/main/java/com/aws/cfn/injection/LambdaModule.java
@@ -1,11 +1,8 @@
-package com.aws.cfn;
+package com.aws.cfn.injection;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.cloudwatchevents.AmazonCloudWatchEvents;
-import com.amazonaws.services.cloudwatchevents.AmazonCloudWatchEventsClient;
 import com.aws.cfn.metrics.MetricsPublisher;
 import com.aws.cfn.metrics.MetricsPublisherImpl;
 import com.aws.cfn.proxy.CallbackAdapter;
@@ -18,9 +15,9 @@ public class LambdaModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(AmazonCloudFormation.class).to(AmazonCloudFormationClient.class);
-        bind(AmazonCloudWatch.class).to(AmazonCloudWatchClient.class);
-        bind(AmazonCloudWatchEvents.class).to(AmazonCloudWatchEventsClient.class);
+        bind(AmazonCloudFormation.class).toProvider(AmazonCloudFormationProvider.class);
+        bind(AmazonCloudWatch.class).toProvider(AmazonCloudWatchProvider.class);
+        bind(AmazonCloudWatchEvents.class).toProvider(AmazonCloudWatchEventsProvider.class);
         bind(MetricsPublisher.class).to(MetricsPublisherImpl.class);
         bind(CallbackAdapter.class).to(CloudFormationCallbackAdapter.class);
         bind(SchemaValidator.class).to(Validator.class);

--- a/src/main/java/com/aws/cfn/metrics/MetricsPublisherImpl.java
+++ b/src/main/java/com/aws/cfn/metrics/MetricsPublisherImpl.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.amazonaws.services.cloudwatch.model.StandardUnit;
 import com.aws.cfn.Action;
-import com.aws.cfn.LambdaModule;
+import com.aws.cfn.injection.LambdaModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;

--- a/src/main/java/com/aws/cfn/proxy/CallbackAdapter.java
+++ b/src/main/java/com/aws/cfn/proxy/CallbackAdapter.java
@@ -1,16 +1,13 @@
 package com.aws.cfn.proxy;
 
-import java.util.Optional;
-
 /**
  * Interface used to abstract the function of reporting back provisioning progress to the handler caller
  */
 public interface CallbackAdapter<T> {
 
     void reportProgress(final String bearerToken,
-                        final Optional<HandlerErrorCode> errorCode,
+                        final HandlerErrorCode errorCode,
                         final ProgressStatus progressStatus,
                         final T resourceModel,
                         final String statusMessage);
-
 }

--- a/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
+++ b/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
@@ -3,13 +3,11 @@ package com.aws.cfn.proxy;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.OperationStatus;
 import com.amazonaws.services.cloudformation.model.RecordHandlerProgressRequest;
-import com.aws.cfn.LambdaModule;
+import com.aws.cfn.injection.LambdaModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import org.json.JSONObject;
-
-import java.util.Optional;
 
 public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
 
@@ -33,7 +31,7 @@ public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
 
     @Override
     public void reportProgress(final String bearerToken,
-                               final Optional<HandlerErrorCode> errorCode,
+                               final HandlerErrorCode errorCode,
                                final ProgressStatus progressStatus,
                                final T resourceModel,
                                final String statusMessage) {
@@ -46,11 +44,12 @@ public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
             request.setResourceModel(new JSONObject(resourceModel).toString());
         }
 
-        errorCode.ifPresent(handlerErrorCode -> request.setErrorCode(translate(handlerErrorCode)));
+        if (errorCode != null) {
+            request.setErrorCode(translate(errorCode));
+        }
 
         // TODO: be far more fault tolerant, do retries, emit logs and metrics, etc.
         this.cloudFormationClient.recordHandlerProgress(request);
-
     }
 
     private com.amazonaws.services.cloudformation.model.HandlerErrorCode translate(final HandlerErrorCode errorCode) {

--- a/src/main/java/com/aws/cfn/proxy/ProgressEvent.java
+++ b/src/main/java/com/aws/cfn/proxy/ProgressEvent.java
@@ -4,8 +4,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.json.JSONObject;
 
-import java.util.Optional;
-
 @Data
 @NoArgsConstructor
 public class ProgressEvent<T> {
@@ -18,7 +16,7 @@ public class ProgressEvent<T> {
     /**
      *  If ProgressStatus is Failed, an error code should be provided
      */
-    private Optional<HandlerErrorCode> errorCode;
+    private HandlerErrorCode errorCode;
 
     /**
      * The handler can (and should) specify a contextual information message which

--- a/src/main/java/com/aws/cfn/scheduler/CloudWatchScheduler.java
+++ b/src/main/java/com/aws/cfn/scheduler/CloudWatchScheduler.java
@@ -9,7 +9,7 @@ import com.amazonaws.services.cloudwatchevents.model.RuleState;
 import com.amazonaws.services.cloudwatchevents.model.Target;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.util.StringUtils;
-import com.aws.cfn.LambdaModule;
+import com.aws.cfn.injection.LambdaModule;
 import com.aws.cfn.proxy.RequestContext;
 import com.google.inject.Guice;
 import com.google.inject.Inject;


### PR DESCRIPTION
*Description of changes:*

* CloudFormation client is using internal version for now so needs specific configuration
* Other default client constructors use the global region endpoints so are no good and we'll probably want to configure retry policies and such anyway
* Fixed an NPE with the use of Optional<T> which is exactly the opposite of what it says on the pack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
