### PR TITLE
Passing a logger interface to the handlers

### DIFF
--- a/src/main/java/com/aws/cfn/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/LambdaWrapper.java
@@ -39,7 +39,7 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler, RequestH
     private final CloudWatchScheduler scheduler;
     private final SchemaValidator validator;
     protected final Serializer serializer;
-    private LambdaLogger logger;
+    protected LambdaLogger logger;
 
     /**
      * This .ctor provided for Lambda runtime which will not automatically invoke Guice injector

--- a/src/main/java/com/aws/cfn/proxy/Logger.java
+++ b/src/main/java/com/aws/cfn/proxy/Logger.java
@@ -1,0 +1,11 @@
+package com.aws.cfn.proxy;
+
+public interface Logger {
+
+    /**
+     * Log a message to the default provider on this runtime.
+     * @param message   the message to emit to log
+     */
+    void log(String message);
+
+}

--- a/src/main/java/com/aws/cfn/proxy/LoggerProxy.java
+++ b/src/main/java/com/aws/cfn/proxy/LoggerProxy.java
@@ -1,0 +1,20 @@
+package com.aws.cfn.proxy;
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
+/**
+ * Proxies logging requests to the default LambdaLogger (CloudWatch Logs)
+ */
+public final class LoggerProxy implements Logger {
+
+    private final LambdaLogger lambdaLogger;
+
+    public LoggerProxy(final LambdaLogger lambdaLogger) {
+        this.lambdaLogger = lambdaLogger;
+    }
+
+    @Override
+    public void log(final String message) {
+        lambdaLogger.log(message);
+    }
+}


### PR DESCRIPTION
*Description of changes:*

Passing a logger interface to the handlers so they can emit diagnostics, which we proxy to the LambdaLogger in this runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
