### PR TITLE
Refactor passing of CallbackContext

### DIFF
--- a/src/main/java/com/aws/cfn/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/LambdaWrapper.java
@@ -172,7 +172,7 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
         final ProgressEvent handlerResponse = invokeHandler(
             resourceHandlerRequest,
             request.getAction(),
-            requestContext);
+            requestContext.getCallbackContext());
         if (handlerResponse != null)
             this.log(String.format("Handler returned %s", handlerResponse.getStatus()));
         else
@@ -269,7 +269,7 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
      */
     public abstract ProgressEvent<T> invokeHandler(final ResourceHandlerRequest<T> request,
                                                    final Action action,
-                                                   final RequestContext context) throws IOException;
+                                                   final JSONObject callbackContext) throws IOException;
 
     /**
      * null-safe logger redirect

--- a/src/main/java/com/aws/cfn/proxy/ResourceHandlerRequest.java
+++ b/src/main/java/com/aws/cfn/proxy/ResourceHandlerRequest.java
@@ -3,7 +3,6 @@ package com.aws.cfn.proxy;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.json.JSONObject;
 
 /**
  * This interface describes the request object for the provisioning request passed to the implementor.
@@ -22,9 +21,4 @@ public class ResourceHandlerRequest<T> {
     private Credentials credentials;
     private T desiredResourceState;
     private T previousResourceState;
-
-    /**
-     * Custom context object to enable handlers to process re-invocation
-     */
-    private JSONObject callbackContext;
 }

--- a/src/test/java/com/aws/cfn/WrapperOverride.java
+++ b/src/test/java/com/aws/cfn/WrapperOverride.java
@@ -4,7 +4,6 @@ import com.aws.cfn.metrics.MetricsPublisher;
 import com.aws.cfn.proxy.CallbackAdapter;
 import com.aws.cfn.proxy.HandlerRequest;
 import com.aws.cfn.proxy.ProgressEvent;
-import com.aws.cfn.proxy.RequestContext;
 import com.aws.cfn.proxy.ResourceHandlerRequest;
 import com.aws.cfn.resource.SchemaValidator;
 import com.aws.cfn.resource.Serializer;
@@ -12,6 +11,7 @@ import com.aws.cfn.scheduler.CloudWatchScheduler;
 import com.google.inject.Inject;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class WrapperOverride<TestModel> extends LambdaWrapper<TestModel> {
     @Override
     public ProgressEvent<TestModel> invokeHandler(final ResourceHandlerRequest<TestModel> request,
                                        final Action action,
-                                       final RequestContext context) {
+                                       final JSONObject callbackContext) {
         return invokeHandlerResponse;
     }
 


### PR DESCRIPTION
*Description of changes:*
Was previously passing the RequestContext (payload from CloudFormation) rather than the handler-specified CallbackContext

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
