### PR TITLE
Workflows changes

### DIFF
--- a/src/main/java/com/aws/cfn/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/LambdaWrapper.java
@@ -9,9 +9,9 @@ import com.aws.cfn.metrics.MetricsPublisher;
 import com.aws.cfn.proxy.CallbackAdapter;
 import com.aws.cfn.proxy.HandlerRequest;
 import com.aws.cfn.proxy.ProgressEvent;
-import com.aws.cfn.proxy.ProgressStatus;
 import com.aws.cfn.proxy.RequestContext;
 import com.aws.cfn.proxy.ResourceHandlerRequest;
+import com.aws.cfn.proxy.OperationStatus;
 import com.aws.cfn.resource.SchemaValidator;
 import com.aws.cfn.resource.Serializer;
 import com.aws.cfn.resource.exceptions.ValidationException;
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import java.util.Map;
 
 public abstract class LambdaWrapper<T> implements RequestStreamHandler {
 
@@ -85,7 +86,6 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
             // decode the input request
             final String input = IOUtils.toString(inputStream, "UTF-8");
             request = this.serializer.deserialize(input, HandlerRequest.class);
-
             handlerResponse = processInvocation(request, context);
         } catch (final Exception e) {
             // Exceptions are wrapped as a consistent error response to the caller (i.e; CloudFormation)
@@ -98,7 +98,7 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
 
             handlerResponse = new ProgressEvent();
             handlerResponse.setMessage(e.getMessage());
-            handlerResponse.setStatus(ProgressStatus.Failed);
+            handlerResponse.setStatus(OperationStatus.FAILED);
             if (request.getRequestData() != null) {
                 handlerResponse.setResourceModel(
                     request.getRequestData().getResourceProperties()
@@ -114,21 +114,22 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
     public ProgressEvent processInvocation(final HandlerRequest request,
                                            final Context context) throws IOException, TerminalException {
 
-        if (request == null || request.getRequestContext() == null) {
+        if (request == null) {
             throw new TerminalException("Invalid request object received");
         }
 
         // transform the request object to pass to caller
         final ResourceHandlerRequest resourceHandlerRequest = transform(request);
-
-        final RequestContext requestContext = request.getRequestContext();
-
-        // If this invocation was triggered by a 're-invoke' CloudWatch Event, clean it up
-        if (requestContext.getCloudWatchEventsRuleName() != null &&
-            !requestContext.getCloudWatchEventsRuleName().isEmpty()) {
-            this.scheduler.cleanupCloudWatchEvents(
-                requestContext.getCloudWatchEventsRuleName(),
-                requestContext.getCloudWatchEventsTargetId());
+        RequestContext requestContext = null;
+        if(request.getRequestContext() != null) {
+            requestContext = request.getRequestContext();
+            // If this invocation was triggered by a 're-invoke' CloudWatch Event, clean it up
+            if (requestContext.getCloudWatchEventsRuleName() != null &&
+                !requestContext.getCloudWatchEventsRuleName().isEmpty()) {
+                this.scheduler.cleanupCloudWatchEvents(
+                    requestContext.getCloudWatchEventsRuleName(),
+                    requestContext.getCloudWatchEventsTargetId());
+            }
         }
 
         // MetricsPublisher is initialised with the resource type name for metrics namespace
@@ -172,7 +173,7 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
         final ProgressEvent handlerResponse = invokeHandler(
             resourceHandlerRequest,
             request.getAction(),
-            requestContext.getCallbackContext());
+            requestContext == null ? null : requestContext.getCallbackContext());
         if (handlerResponse != null)
             this.log(String.format("Handler returned %s", handlerResponse.getStatus()));
         else
@@ -190,40 +191,55 @@ public abstract class LambdaWrapper<T> implements RequestStreamHandler {
             throw new TerminalException("Handler failed to provide a response.");
         }
 
-        // When the handler responses InProgress with a callback delay, we trigger a callback to re-invoke
+        // When the handler responses IN_PROGRESS with a callback delay, we trigger a callback to re-invoke
         // the handler for the Resource type to implement stabilization checks and long-poll creation checks
-        if (handlerResponse.getStatus() == ProgressStatus.InProgress) {
+        if (handlerResponse.getStatus() == OperationStatus.IN_PROGRESS) {
             final RequestContext callbackContext = new RequestContext();
-            callbackContext.setInvocation(requestContext.getInvocation() + 1);
+            if(requestContext != null) {
+                callbackContext.setInvocation(requestContext.getInvocation() + 1);
+            } else {
+                callbackContext.setInvocation(1);
+            }
+
             callbackContext.setCallbackContext(handlerResponse.getCallbackContext());
+            request.setRequestContext(callbackContext);
 
             this.scheduler.rescheduleAfterMinutes(
                 context.getInvokedFunctionArn(),
                 handlerResponse.getCallbackDelayMinutes(),
-                callbackContext);
+                request);
 
-            // report the progress status when in non-terminal state (i.e; InProgress) back to configured endpoint
+            // report the progress status when in non-terminal state (i.e; IN_PROGRESS) back to configured endpoint
             this.callbackAdapter.reportProgress(request.getBearerToken(),
                 handlerResponse.getErrorCode(),
                 handlerResponse.getStatus(),
                 handlerResponse.getResourceModel(),
                 handlerResponse.getMessage());
         }
-
         // The wrapper will log any context to the configured CloudWatch log group
-        if (handlerResponse.getCallbackContext() != null)
-            this.log(handlerResponse.getCallbackContext().toString());
+        else if (requestContext != null) {
+            this.callbackAdapter.reportProgress(request.getBearerToken(),
+                    handlerResponse.getErrorCode(),
+                    handlerResponse.getStatus(),
+                    handlerResponse.getResourceModel(),
+                    handlerResponse.getMessage());
+        }
 
         return handlerResponse;
     }
 
     private Response<T> createProgressResponse(final ProgressEvent<T> progressEvent) throws JsonProcessingException {
         final Response<T> response = new Response<>();
-        response.setMessage(progressEvent.getMessage());
-        response.setStatus(progressEvent.getStatus());
 
+
+
+        response.setMessage(progressEvent.getMessage());
+        response.setOperationStatus(progressEvent.getStatus());
         if (progressEvent.getResourceModel() != null) {
-            response.setResourceModel(progressEvent.getResourceModel());
+            Map<String, Object> resourceModel = serializer.serializeToMap(progressEvent.getResourceModel());
+            ResponseData responseData = new ResponseData();
+            responseData.setResourceModel(resourceModel);
+            response.setResponseData(responseData);
         }
 
         return response;

--- a/src/main/java/com/aws/cfn/Response.java
+++ b/src/main/java/com/aws/cfn/Response.java
@@ -1,15 +1,15 @@
 package com.aws.cfn;
 
-import com.aws.cfn.proxy.ProgressStatus;
+import com.aws.cfn.proxy.OperationStatus;
 import lombok.Data;
 
 @Data
 public class Response<T> {
     /**
-     * The status indicates whether the handler has reached a terminal state or
+     * The operationStatus indicates whether the handler has reached a terminal state or
      * is still computing and requires more time to complete
      */
-    private ProgressStatus status;
+    private OperationStatus operationStatus;
 
     /**
      * The handler can (and should) specify a contextual information message which
@@ -22,5 +22,5 @@ public class Response<T> {
      * The output resource instance populated by a READ/LIST for synchronous results
      * and by CREATE/UPDATE/DELETE for final response validation/confirmation
      */
-    private T resourceModel;
+    private ResponseData responseData;
 }

--- a/src/main/java/com/aws/cfn/ResponseData.java
+++ b/src/main/java/com/aws/cfn/ResponseData.java
@@ -1,0 +1,9 @@
+package com.aws.cfn;
+import lombok.Data;
+import java.util.Map;
+
+@Data
+public class ResponseData {
+
+    private Map<String, Object> resourceModel;
+}

--- a/src/main/java/com/aws/cfn/injection/AmazonCloudFormationProvider.java
+++ b/src/main/java/com/aws/cfn/injection/AmazonCloudFormationProvider.java
@@ -10,8 +10,8 @@ public class AmazonCloudFormationProvider implements Provider<AmazonCloudFormati
     @Override
     public AmazonCloudFormation get() {
          final EndpointConfiguration endpointConfiguration = new EndpointConfiguration(
-            "https://stackbuilder.us-west-2.amazonaws.com",
-        "us-west-2");
+            "https://stackbuilder-2.amazonaws.com",
+        "eu-west-1");
 
         return AmazonCloudFormationClientBuilder.standard()
             .withEndpointConfiguration(endpointConfiguration)

--- a/src/main/java/com/aws/cfn/proxy/CallbackAdapter.java
+++ b/src/main/java/com/aws/cfn/proxy/CallbackAdapter.java
@@ -7,7 +7,7 @@ public interface CallbackAdapter<T> {
 
     void reportProgress(final String bearerToken,
                         final HandlerErrorCode errorCode,
-                        final ProgressStatus progressStatus,
+                        final OperationStatus operationStatus,
                         final T resourceModel,
                         final String statusMessage);
 }

--- a/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
+++ b/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
@@ -1,7 +1,6 @@
 package com.aws.cfn.proxy;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.OperationStatus;
 import com.amazonaws.services.cloudformation.model.RecordHandlerProgressRequest;
 import com.aws.cfn.injection.LambdaModule;
 import com.google.inject.Guice;
@@ -32,12 +31,12 @@ public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
     @Override
     public void reportProgress(final String bearerToken,
                                final HandlerErrorCode errorCode,
-                               final ProgressStatus progressStatus,
+                               final OperationStatus operationStatus,
                                final T resourceModel,
                                final String statusMessage) {
         final RecordHandlerProgressRequest request = new RecordHandlerProgressRequest()
             .withBearerToken(bearerToken)
-            .withOperationStatus(translate(progressStatus))
+            .withOperationStatus(translate(operationStatus))
             .withStatusMessage(statusMessage);
 
         if (resourceModel != null) {
@@ -86,17 +85,17 @@ public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
         }
     }
 
-    private com.amazonaws.services.cloudformation.model.OperationStatus translate(final ProgressStatus progressStatus) {
-        switch (progressStatus) {
-            case Complete:
-                return OperationStatus.COMPLETE;
-            case Failed:
-                return OperationStatus.FAILED;
-            case InProgress:
-                return OperationStatus.IN_PROGRESS;
+    private com.amazonaws.services.cloudformation.model.OperationStatus translate(final OperationStatus operationStatus) {
+        switch (operationStatus) {
+            case COMPLETE:
+                return com.amazonaws.services.cloudformation.model.OperationStatus.COMPLETE;
+            case FAILED:
+                return com.amazonaws.services.cloudformation.model.OperationStatus.FAILED;
+            case IN_PROGRESS:
+                return com.amazonaws.services.cloudformation.model.OperationStatus.IN_PROGRESS;
             default:
                 // default will be to fail on unknown status
-                return OperationStatus.FAILED;
+                return com.amazonaws.services.cloudformation.model.OperationStatus.FAILED;
         }
     }
 }

--- a/src/main/java/com/aws/cfn/proxy/HandlerResponse.java
+++ b/src/main/java/com/aws/cfn/proxy/HandlerResponse.java
@@ -14,7 +14,7 @@ public class HandlerResponse<T> {
     private String errorCode;
     private String message;
     private String nextToken;
-    private ProgressStatus operationStatus;
+    private OperationStatus operationStatus;
     private ResponseData<T> responseData;
     private StabilizationData stabilizationData;
 }

--- a/src/main/java/com/aws/cfn/proxy/OperationStatus.java
+++ b/src/main/java/com/aws/cfn/proxy/OperationStatus.java
@@ -1,0 +1,7 @@
+package com.aws.cfn.proxy;
+
+public enum OperationStatus {
+    IN_PROGRESS,
+    COMPLETE,
+    FAILED
+}

--- a/src/main/java/com/aws/cfn/proxy/ProgressEvent.java
+++ b/src/main/java/com/aws/cfn/proxy/ProgressEvent.java
@@ -11,10 +11,10 @@ public class ProgressEvent<T> {
      * The status indicates whether the handler has reached a terminal state or
      * is still computing and requires more time to complete
      */
-    private ProgressStatus status;
+    private OperationStatus status;
 
     /**
-     *  If ProgressStatus is Failed, an error code should be provided
+     *  If OperationStatus is FAILED, an error code should be provided
      */
     private HandlerErrorCode errorCode;
 
@@ -27,7 +27,7 @@ public class ProgressEvent<T> {
 
     /**
      * The callback context is an arbitrary datum which the handler can return
-     * in an InProgress event to allow the passing through of additional state
+     * in an IN_PROGRESS event to allow the passing through of additional state
      * or metadata between subsequent retries; for example to pass through a
      * Resource identifier which can be used to continue polling for stabilization
      */

--- a/src/main/java/com/aws/cfn/proxy/ProgressStatus.java
+++ b/src/main/java/com/aws/cfn/proxy/ProgressStatus.java
@@ -1,7 +1,0 @@
-package com.aws.cfn.proxy;
-
-public enum ProgressStatus {
-    InProgress,
-    Complete,
-    Failed
-}

--- a/src/main/java/com/aws/cfn/resource/Serializer.java
+++ b/src/main/java/com/aws/cfn/resource/Serializer.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Serializer {
 
@@ -38,6 +40,9 @@ public class Serializer {
         return new JSONObject(objectMapper.writeValueAsString(modelObject));
     }
 
+    public Map<String, Object> serializeToMap(final Object modelObject) throws JsonProcessingException {
+        return objectMapper.convertValue(modelObject, Map.class);
+    }
     public <T> T deserialize(final Object o,
                              final Class<T> valueType) throws IOException {
         return deserialize(objectMapper.writeValueAsString(o), valueType);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR encompasses a large amount of changes to the wrapper to handle integration with CloudFormation. Changes include:

* Modifying response object to match what is expected by CloudFormation

* Reporting handler progress to CloudFormation in other cases than when the handler is returning `IN_PROGRESS`. If the handler gets reinvoked by CloudWatch after returning `IN_PROGRESS` initially, this ensures that the next invocation will report handler progress even if the handler returns `COMPLETE` or `FAILED`.

* Changing ProgressStatus enum to OperationStatus and all caps (`Create` to `CREATE`) to account for incoming request serialization

* Adds some null checks to avoid null pointer exceptions

* Passes whole handler request as input to CloudWatch reinvocation

* Changes ordering of CloudWatch event rule cleanup to clean targets then events

* Unit test fixes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
