### PR TITLE
Package all build artifacts for easy distribution

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,15 +1,22 @@
 version: 0.2
 phases:
-  pre_build:
+  install:
     commands:
-      - pip install --upgrade pip wheel
-      - pip install "$CODEBUILD_SRC_DIR_RPDK"
-      - pip install "$CODEBUILD_SRC_DIR"
-      - aws configure add-model --service-model "file://$CODEBUILD_SRC_DIR_RPDK/cloudformation-2010-05-15.normal.json" --service-name cloudformation
+      # make sure pip/setuptools/wheel is up to date
+      - pip install --upgrade pip setuptools wheel
+      - mkdir "$CODEBUILD_SRC_DIR/artifacts"
   build:
     commands:
+      # install aws-cloudformation-rpdk
+      - cd "$CODEBUILD_SRC_DIR_RPDK"
+      - python3 setup.py sdist bdist_wheel
+      - cp dist/* "$CODEBUILD_SRC_DIR/artifacts/"
+      - cp "cloudformation-2010-05-15.normal.json" "$CODEBUILD_SRC_DIR/artifacts/"
+      - pip install dist/*.whl
+      # patch boto3/awscli with internal SDK (must be done after RPDK is installed, since awscli is a dep)
+      - aws configure add-model --service-model "file://$CODEBUILD_SRC_DIR_RPDK/cloudformation-2010-05-15.normal.json" --service-name cloudformation
+      # install internal SDK (Java)
       - cd "$CODEBUILD_SRC_DIR_SDK"
-      - pwd
       - ls -la
       - >
         mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file --batch-mode
@@ -19,21 +26,31 @@ phases:
         -Dversion=1.11.485-PATCH
         -Dpackaging=jar
         -DgeneratePom=true
+      # install aws-cloudformation-resource-schema (Java)
       - cd "$CODEBUILD_SRC_DIR_SCHEMA"
-      - pwd
       - ls -la
       - mvn package org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install --batch-mode
+      # install aws-cloudformation-rpdk-java-plugin (Java)
       - cd "$CODEBUILD_SRC_DIR"
-      - pwd
       - ls -la
       - mvn package org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install --batch-mode
+      - cp "target/ResourceProviderRuntime-1.0.jar" "$CODEBUILD_SRC_DIR/artifacts"
+      # install aws-cloudformation-rpdk-java-plugin (Python)
+      - python3 setup.py sdist bdist_wheel
+      - cp dist/* "$CODEBUILD_SRC_DIR/artifacts"
+      - pip install dist/*.whl
+      # end-to-end test
       - DIR=$(mktemp -d)
       - cd "$DIR"
-      - pwd
       - ls -la
       - echo "AWS::Foo::Bar" | uluru-cli init -vv
       - mvn package
       - ls -la
+  post_build:
+    commands:
+      - ls -la "$CODEBUILD_SRC_DIR/artifacts"
 artifacts:
   files:
-    - target/ResourceProviderRuntime-1.0.jar
+    - '*'
+  base-directory: artifacts
+  discard-paths: yes


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Include all artifacts we need to run the toolkit, so we can just distribute the resulting zip file.

* The CI artifacts are namespaced by build ID (there is a "View artifacts") link at the top of a CodeBuild run that will take you to the right one)
* All CI artifacts are zipped into one file, which includes not only the jar of the plugin, but also all supporting files.

Best way to review this is to click through to the Codebuild run, click "View artifacts" at the top under "Build status", download the artifact from S3, unzip it and see what's inside.

I've also changed the CI to install the Python artifacts/wheels, instead of installing the source code like we do in development. This means we should catch any packaging issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
