### PR TITLE
Managed submit support (package Java artifacts correctly)

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,8 +2,8 @@ version: 0.2
 phases:
   install:
     commands:
-      # make sure pip/setuptools/wheel is up to date
-      - pip install --upgrade pip setuptools wheel -r requirements.txt
+      # make sure pip/setuptools/wheel is up to date, awscli for SDK patching
+      - pip install --upgrade pip setuptools wheel awscli -r requirements.txt
       - mkdir "$CODEBUILD_SRC_DIR/artifacts"
   build:
     commands:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Changes to Java plugin corresponding to core changes to managed workflow (https://github.com/aws-cloudformation/aws-cloudformation-rpdk/pull/217). Packages all Java sources, and ensures the JAR file is also present, built, and uploaded (schema is handled by the core). It's currently possible for the JAR file to be out of date, I don't have a good solution for this other than shelling out and running `mvn package` during the command?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
