### PR TITLE
Initial pieces of IterationProvider hooks and handlers

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -11,7 +11,7 @@ from .utils import safe_reserved
 
 LOG = logging.getLogger(__name__)
 
-OPERATIONS = ("Create", "Read", "Update", "Delete", "List")
+OPERATIONS = ["Generate"]
 EXECUTABLE = "uluru-cli"
 
 
@@ -19,7 +19,7 @@ class JavaLanguagePlugin(LanguagePlugin):
     MODULE_NAME = __name__
     NAME = "java"
     RUNTIME = "java8"
-    ENTRY_POINT = "{}.HandlerWrapper::handleRequest"
+    ENTRY_POINT = "{}.IterationProviderHandlerWrapper::handleRequest"
     CODE_URI = "./target/{}-1.0-SNAPSHOT.jar"
 
     def __init__(self):
@@ -75,7 +75,7 @@ class JavaLanguagePlugin(LanguagePlugin):
         project.safewrite(path, contents)
 
         LOG.debug("Writing stub handlers")
-        template = self.env.get_template("StubHandler.java")
+        template = self.env.get_template("StubIterationProviderHandler.java")
 
         for operation in OPERATIONS:
             path = src / "{}Handler.java".format(operation)
@@ -83,7 +83,7 @@ class JavaLanguagePlugin(LanguagePlugin):
             contents = template.render(
                 package_name=self.package_name,
                 operation=operation,
-                pojo_name="ResourceModel",
+                pojo_name="HandlerInputModel",
             )
             project.safewrite(path, contents)
 
@@ -132,13 +132,13 @@ class JavaLanguagePlugin(LanguagePlugin):
         LOG.debug("Making generated folder structure: %s", src)
         src.mkdir(parents=True, exist_ok=True)
 
-        path = src / "HandlerWrapper.java"
+        path = src / "IterationProviderHandlerWrapper.java"
         LOG.debug("Writing handler wrapper: %s", path)
-        template = self.env.get_template("HandlerWrapper.java")
+        template = self.env.get_template("IterationProviderHandlerWrapper.java")
         contents = template.render(
             package_name=self.package_name,
             operations=OPERATIONS,
-            pojo_name="ResourceModel",
+            pojo_name="HandlerInputModel",
         )
         project.overwrite(path, contents)
 
@@ -150,17 +150,17 @@ class JavaLanguagePlugin(LanguagePlugin):
         )
         project.overwrite(path, contents)
 
-        path = src / "BaseHandler.java"
+        path = src / "BaseIterationProviderHandler.java"
         LOG.debug("Writing base handler: %s", path)
-        template = self.env.get_template("BaseHandler.java")
+        template = self.env.get_template("BaseIterationProviderHandler.java")
         contents = template.render(
             package_name=self.package_name,
             operations=OPERATIONS,
-            pojo_name="ResourceModel",
+            pojo_name="HandlerInputModel",
         )
         project.overwrite(path, contents)
 
-        pojo_resolver = JavaPojoResolver(objects, "ResourceModel")
+        pojo_resolver = JavaPojoResolver(objects, "HandlerInputModel")
         pojos = pojo_resolver.resolve_pojos()
 
         LOG.debug("Writing %d POJOs", len(pojos))
@@ -181,7 +181,7 @@ class JavaLanguagePlugin(LanguagePlugin):
         template = self.env.get_template("HandlerModule.java")
         contents = template.render(
             package_name=self.package_name,
-            pojo_name="ResourceModel"
+            pojo_name="HandlerInputModel"
         )
         project.overwrite(path, contents)
 

--- a/python/rpdk/java/templates/BaseIterationProviderHandler.java
+++ b/python/rpdk/java/templates/BaseIterationProviderHandler.java
@@ -1,0 +1,19 @@
+// This is a generated file. Modifications will be overwritten.
+package {{ package_name }};
+
+import com.aws.cfn.oasis.model.ProgressEvent;
+import com.aws.cfn.oasis.model.IterationProviderHandlerRequest;
+import com.aws.cfn.proxy.AmazonWebServicesClientProxy;
+import com.aws.cfn.proxy.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class BaseIterationProviderHandler<CallbackT> {
+    public abstract ProgressEvent handleRequest(
+            @Nonnull final AmazonWebServicesClientProxy proxy,
+            @Nonnull final IterationProviderHandlerRequest request,
+            @Nullable final CallbackT callbackContext,
+            @Nonnull final Logger logger
+    );
+}

--- a/python/rpdk/java/templates/HandlerModule.java
+++ b/python/rpdk/java/templates/HandlerModule.java
@@ -1,18 +1,21 @@
 package {{ package_name }};
 
 import com.aws.cfn.injection.CloudFormationProvider;
+import com.aws.cfn.oasis.model.iteration.Iteration;
 import com.aws.cfn.proxy.CallbackAdapter;
 import com.aws.cfn.proxy.CloudFormationCallbackAdapter;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient;
 
+import java.util.Collection;
+
 public class HandlerModule extends AbstractModule {
 
     @Override
     protected void configure() {
         bind(CloudFormationAsyncClient.class).toProvider(CloudFormationProvider.class);
-        bind(new TypeLiteral<CallbackAdapter<{{ pojo_name }}>>() {})
-                .to(new TypeLiteral<CloudFormationCallbackAdapter<{{ pojo_name }}>>() {});
+        bind(new TypeLiteral<CallbackAdapter<Collection<Iteration>>>() {})
+                .to(new TypeLiteral<CloudFormationCallbackAdapter<Collection<Iteration>>>() {});
     }
 }

--- a/python/rpdk/java/templates/IterationProviderHandlerWrapper.java
+++ b/python/rpdk/java/templates/IterationProviderHandlerWrapper.java
@@ -1,0 +1,77 @@
+// This is a generated file. Modifications will be overwritten.
+package {{ package_name }};
+
+import com.aws.cfn.Action;
+import com.aws.cfn.oasis.LambdaWrapper;
+import com.aws.cfn.metrics.MetricsPublisher;
+import com.aws.cfn.oasis.model.ProgressEvent;
+import com.aws.cfn.oasis.model.IterationProviderHandlerRequest;
+import com.aws.cfn.proxy.AmazonWebServicesClientProxy;
+import com.aws.cfn.proxy.CallbackAdapter;
+import com.aws.cfn.oasis.model.IterationProviderWrapperRequest;
+import com.aws.cfn.proxy.LoggerProxy;
+import com.aws.cfn.proxy.RequestContext;
+import com.aws.cfn.resource.SchemaValidator;
+import com.aws.cfn.resource.Serializer;
+import com.aws.cfn.oasis.scheduler.CloudWatchScheduler;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Guice;
+import com.google.inject.TypeLiteral;
+import com.google.inject.Key;
+import com.aws.cfn.oasis.model.iteration.Iteration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class IterationProviderHandlerWrapper extends LambdaWrapper<{{ pojo_name }}, CallbackContext> {
+
+    private final Configuration configuration = new Configuration();
+    private final Map<Action, BaseIterationProviderHandler> handlers = new HashMap<>();
+
+    public IterationProviderHandlerWrapper() {
+    }
+
+    @Inject
+    public IterationProviderHandlerWrapper(final CallbackAdapter<Collection<Iteration>> callbackAdapter,
+                                           final MetricsPublisher metricsPublisher,
+                                           final CloudWatchScheduler scheduler,
+                                           final SchemaValidator validator,
+                                           final Serializer serializer,
+                                           final TypeReference<IterationProviderWrapperRequest<{{ pojo_name }}, CallbackContext>> typeReference) {
+        super(callbackAdapter, metricsPublisher, scheduler, validator, serializer, typeReference);
+    }
+
+    @Override
+    public ProgressEvent<CallbackContext> invokeHandler(final AmazonWebServicesClientProxy proxy,
+                                                        final IterationProviderHandlerRequest<{{ pojo_name }}> request,
+                                                        final Action action,
+                                                        final CallbackContext callbackContext) {
+
+        final String actionName = (action == null) ? "<null>" : action.toString(); // paranoia
+        final LoggerProxy loggerProxy = new LoggerProxy(this.logger);
+        final BaseIterationProviderHandler handler = new GenerateHandler();
+
+        return handler.handleRequest(proxy, request, callbackContext, loggerProxy);
+    }
+
+    @Override
+    public InputStream provideSchema() {
+        return this.configuration.schema();
+    }
+
+    @Override
+    protected CallbackAdapter<Collection<Iteration>> getCallbackAdapter() {
+        final Injector injector = Guice.createInjector(new HandlerModule());
+        return injector.getInstance(Key.get(new TypeLiteral<CallbackAdapter<Collection<Iteration>>>() {}));
+    }
+
+    @Override
+    protected TypeReference<IterationProviderWrapperRequest<{{ pojo_name }}, CallbackContext>> getInputTypeReference() {
+        return new TypeReference<IterationProviderWrapperRequest<{{ pojo_name }}, CallbackContext>>() {};
+    }
+}

--- a/python/rpdk/java/templates/StubConfiguration.java
+++ b/python/rpdk/java/templates/StubConfiguration.java
@@ -8,7 +8,7 @@ class Configuration extends BaseConfiguration {
         super("{{ schema_file_name }}");
     }
 
-    public InputStream resourceSchema() {
+    public InputStream schema() {
         return this.getClass().getClassLoader().getResourceAsStream(schemaFilename);
     }
 

--- a/python/rpdk/java/templates/StubIterationProviderHandler.java
+++ b/python/rpdk/java/templates/StubIterationProviderHandler.java
@@ -1,0 +1,32 @@
+package {{ package_name }};
+
+import com.aws.cfn.oasis.model.IterationProviderHandlerRequest;
+import com.aws.cfn.oasis.model.ProgressEvent;
+import com.aws.cfn.oasis.model.iteration.ApplyTemplateIteration;
+import com.aws.cfn.oasis.model.nextaction.NextActionApplyIterations;
+import com.aws.cfn.proxy.AmazonWebServicesClientProxy;
+import com.aws.cfn.proxy.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class {{ operation }}Handler extends BaseIterationProviderHandler<CallbackContext> {
+
+    @Override
+    public ProgressEvent handleRequest(@Nonnull final AmazonWebServicesClientProxy proxy,
+                                       @Nonnull final IterationProviderHandlerRequest request,
+                                       @Nullable final CallbackContext callbackContext,
+                                       @Nonnull final Logger logger) {
+        Objects.requireNonNull(proxy);
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(logger);
+
+        // TODO produce the templates and stuff for demo
+
+        return new ProgressEvent<CallbackContext>(new NextActionApplyIterations<>(Arrays.asList(
+        new ApplyTemplateIteration(request.getTemplates().getFinalTemplate())
+        )));
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/oasis/LambdaWrapper.java
@@ -1,0 +1,346 @@
+package com.aws.cfn.oasis;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.aws.cfn.Action;
+import com.aws.cfn.exceptions.TerminalException;
+import com.aws.cfn.injection.LambdaModule;
+import com.aws.cfn.metrics.MetricsPublisher;
+import com.aws.cfn.oasis.model.IterationProviderHandlerRequest;
+import com.aws.cfn.oasis.model.IterationProviderWrapperRequest;
+import com.aws.cfn.oasis.model.ProgressEvent;
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.oasis.model.OperationInfo;
+import com.aws.cfn.oasis.model.iteration.Iteration;
+import com.aws.cfn.oasis.model.nextaction.NextActionFail;
+import com.aws.cfn.proxy.AmazonWebServicesClientProxy;
+import com.aws.cfn.proxy.CallbackAdapter;
+import com.aws.cfn.proxy.HandlerErrorCode;
+import com.aws.cfn.proxy.OperationStatus;
+import com.aws.cfn.proxy.RequestContext;
+import com.aws.cfn.resource.SchemaValidator;
+import com.aws.cfn.resource.Serializer;
+import com.aws.cfn.resource.exceptions.ValidationException;
+import com.aws.cfn.oasis.scheduler.CloudWatchScheduler;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONObject;
+import software.amazon.awssdk.utils.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Handles the translation from request from the CloudFormation service to invoking the
+ * handler itself
+ */
+public abstract class LambdaWrapper<InputT, CallbackT> implements RequestStreamHandler {
+
+    private final CallbackAdapter<Collection<Iteration>> callbackAdapter;
+    private final MetricsPublisher metricsPublisher;
+    private final CloudWatchScheduler scheduler;
+    private final SchemaValidator validator;
+    private final TypeReference<IterationProviderWrapperRequest<InputT, CallbackT>> inputTypeReference;
+    protected final Serializer serializer;
+    protected LambdaLogger logger;
+
+
+    /**
+     * This .ctor provided for Lambda runtime which will not automatically invoke Guice injector
+     */
+    @SuppressWarnings("unused")
+    public LambdaWrapper() {
+        Injector injector = Guice.createInjector(new LambdaModule());
+        this.callbackAdapter = getCallbackAdapter();
+        this.metricsPublisher = injector.getInstance(MetricsPublisher.class);
+        this.scheduler = new CloudWatchScheduler();
+        this.serializer = new Serializer();
+        this.validator = injector.getInstance(SchemaValidator.class);
+        this.inputTypeReference = getInputTypeReference();
+    }
+
+    /**
+     * This .ctor provided for testing
+     */
+    @Inject
+    @VisibleForTesting
+    public LambdaWrapper(@Nonnull final CallbackAdapter<Collection<Iteration>> callbackAdapter,
+                         @Nonnull final MetricsPublisher metricsPublisher,
+                         @Nonnull final CloudWatchScheduler scheduler,
+                         @Nonnull final SchemaValidator validator,
+                         @Nonnull final Serializer serializer,
+                         @Nonnull final TypeReference<IterationProviderWrapperRequest<InputT, CallbackT>> inputTypeReference) {
+        this.callbackAdapter = Objects.requireNonNull(callbackAdapter);
+        this.metricsPublisher = Objects.requireNonNull(metricsPublisher);
+        this.scheduler = Objects.requireNonNull(scheduler);
+        this.serializer = Objects.requireNonNull(serializer);
+        this.validator = Objects.requireNonNull(validator);
+        this.inputTypeReference = Objects.requireNonNull(inputTypeReference);
+    }
+
+    public void handleRequest(@Nonnull final InputStream inputStream,
+                              @Nonnull final OutputStream outputStream,
+                              @Nonnull final Context context) throws IOException, TerminalException {
+        Objects.requireNonNull(inputStream);
+        Objects.requireNonNull(outputStream);
+        Objects.requireNonNull(context);
+
+        ProgressEvent<CallbackT> handlerResponse = null;
+        IterationProviderWrapperRequest<InputT, CallbackT> request = null;
+
+        try {
+            this.logger = context.getLogger();
+            this.scheduler.setLogger(context.getLogger());
+
+            // decode the input request
+            final String input = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            request = this.serializer.deserialize(input, inputTypeReference);
+            handlerResponse = processInvocation(request, context);
+        } catch (final Exception ex) {
+            // Exceptions are wrapped as a consistent error response to the caller (i.e; CloudFormation)
+            ex.printStackTrace(); // for root causing - logs to LambdaLogger by default
+
+            handlerResponse = new ProgressEvent<>(new NextActionFail<>(ex.getMessage(), HandlerErrorCode.InternalFailure));
+
+            final Action action = Optional.ofNullable(request)
+                                          .map(IterationProviderWrapperRequest::getOperationInfo)
+                                          .map(OperationInfo::getAction)
+                                          .orElse(null);
+
+            // this.metricsPublisher.publishExceptionMetric(
+            //         Instant.from(OffsetDateTime.now(ZoneOffset.UTC).toInstant()),
+            //         action,
+            //         ex
+            // );
+        } finally {
+            if (request != null && handlerResponse != null) {
+                // A response will be output on all paths, though CloudFormation will
+                // not block on invoking the handlers, but rather listen for callbacks
+                writeResponse(outputStream, createProgressResponse(
+                        handlerResponse,
+                        request.getBearerToken()
+                ));
+            }
+        }
+    }
+
+    public ProgressEvent<CallbackT> processInvocation(@Nonnull final IterationProviderWrapperRequest<InputT, CallbackT> request,
+                                                      @Nonnull final Context context) throws IOException, TerminalException {
+
+        if (request == null) throw new TerminalException("Invalid request object received");
+        if (context == null) throw new TerminalException("Invalid context object received");
+
+        // transform the request object to pass to caller
+        final IterationProviderHandlerRequest<InputT> handlerRequest = transform(request);
+
+        final Optional<RequestContext<CallbackT>> requestContext = Optional.ofNullable(request.getRequestContext());
+
+        requestContext.ifPresent(rc -> {
+            // If this invocation was triggered by a 're-invoke' CloudWatch Event, clean it up
+            final String cloudWatchEventsRuleName = rc.getCloudWatchEventsRuleName();
+            if (!StringUtils.isBlank(cloudWatchEventsRuleName)) {
+                this.scheduler.cleanupCloudWatchEvents(
+                        cloudWatchEventsRuleName,
+                        rc.getCloudWatchEventsTargetId()
+                );
+            }
+        });
+
+        // MetricsPublisher is initialised with the resource type name for metrics namespace
+        // TODO fixup the metrics story for hooks
+        // this.metricsPublisher.publishInvocationMetric(
+        //         Instant.from(OffsetDateTime.now(ZoneOffset.UTC).toInstant()),
+        //         request.getOperationInfo().getAction()
+        // );
+
+        // for CUD actions, validate incoming model - any error is a terminal failure on the invocation
+        try {
+            validateModel(this.serializer.serialize(handlerRequest.getConfiguration()));
+        } catch (final ValidationException e) {
+            // TODO: we'll need a better way to expose the stack of causing exceptions for user feedback
+            final StringBuilder validationMessageBuilder = new StringBuilder();
+            validationMessageBuilder.append(String.format("Model validation failed (%s)\n", e.getMessage()));
+            for (final ValidationException cause : e.getCausingExceptions()) {
+                validationMessageBuilder.append(String.format(
+                        "%s (%s)",
+                        cause.getMessage(),
+                        cause.getSchemaLocation()
+                ));
+            }
+            throw new TerminalException(validationMessageBuilder.toString(), e);
+        }
+
+        // TODO: implement decryption of request and returned callback context
+        // using KMS Key accessible by the Lambda execution Role
+
+        // TODO: implement the handler invocation inside a time check which will abort and automatically
+        // reschedule a callback if the handler does not respond within the 15 minute invocation window
+
+        // TODO: ensure that any credential expiry time is also considered in the time check to
+        // automatically fail a request if the handler will not be able to complete within that period,
+        // such as before a FAS token expires
+
+        final Date startTime = Date.from(OffsetDateTime.now(ZoneOffset.UTC).toInstant());
+
+        // last mile proxy creation with passed-in credentials
+        final AmazonWebServicesClientProxy awsClientProxy = new AmazonWebServicesClientProxy(
+                this.logger,
+                request.getCredentials()
+        );
+
+        final ProgressEvent<CallbackT> handlerResponse = invokeHandler(
+                awsClientProxy,
+                handlerRequest,
+                request.getOperationInfo().getAction(),
+                requestContext.map(RequestContext::getCallbackContext).orElse(null)
+        );
+
+        if (handlerResponse != null) {
+            this.log(String.format("Handler returned %s", handlerResponse.getNextAction().getOperationStatus()));
+        } else {
+            this.log("Handler returned null");
+        }
+
+        final Date endTime = Date.from(OffsetDateTime.now(ZoneOffset.UTC).toInstant());
+
+        // metricsPublisher.publishDurationMetric(
+        //         Instant.from(OffsetDateTime.now(ZoneOffset.UTC).toInstant()),
+        //         request.getOperationInfo().getAction(),
+        //         (endTime.getTime() - startTime.getTime())
+        // );
+
+        // ensure we got a valid response
+        if (handlerResponse == null) {
+            throw new TerminalException("Handler failed to provide a response.");
+        }
+
+        final Response<CallbackT> response = createProgressResponse(
+                handlerResponse,
+                request.getBearerToken()
+        );
+
+        // When the handler responses IN_PROGRESS with a callback delay, we trigger a callback to re-invoke
+        // the handler for the Resource type to implement stabilization checks and long-poll creation checks
+        if (handlerResponse.getNextAction().getOperationStatus() == OperationStatus.IN_PROGRESS) {
+            final RequestContext<CallbackT> reinvocationContext = new RequestContext<>();
+
+            int counter = 1;
+            counter += requestContext.map(RequestContext::getInvocation).orElse(0);
+            reinvocationContext.setInvocation(counter);
+
+            reinvocationContext.setCallbackContext(response.getCallbackContext());
+            final IterationProviderWrapperRequest<InputT, CallbackT> reinvocationRequest = request.toBuilder().requestContext(reinvocationContext).build();
+
+            this.scheduler.rescheduleAfterMinutes(
+                    context.getInvokedFunctionArn(),
+                    response.getCallbackDelayMinutes(),
+                    reinvocationRequest
+            );
+        }
+
+        // report the progress status back to configured endpoint
+        this.callbackAdapter.reportProgress(
+                response.getBearerToken(),
+                response.getErrorCode(),
+                response.getOperationStatus(),
+                response.getOutputModel(),
+                response.getMessage()
+        );
+
+        return handlerResponse;
+    }
+
+    private Response<CallbackT> createProgressResponse(@Nonnull final ProgressEvent<CallbackT> progressEvent,
+                                                       @Nonnull final String bearerToken) {
+        Objects.requireNonNull(progressEvent);
+        Objects.requireNonNull(bearerToken);
+
+        final Response<CallbackT> response = new Response<>();
+        response.setOperationStatus(progressEvent.getNextAction().getOperationStatus());
+        progressEvent.getNextAction().decorateResponse(response);
+        response.setBearerToken(bearerToken);
+        return response;
+    }
+
+    private void writeResponse(final OutputStream outputStream,
+                               final Response<CallbackT> response) throws IOException {
+
+        final JSONObject output = this.serializer.serialize(response);
+        outputStream.write(output.toString().getBytes(StandardCharsets.UTF_8));
+        outputStream.close();
+    }
+
+    private void validateModel(final JSONObject modelObject) throws ValidationException {
+        final InputStream resourceSchema = provideSchema();
+        if (resourceSchema == null) {
+            throw new ValidationException(
+                    "Unable to validate incoming model as no schema was provided.",
+                    null,
+                    null
+            );
+        }
+
+        this.validator.validateObject(modelObject, resourceSchema);
+    }
+
+    /**
+     * Transforms the incoming request to the subset of typed models which the handler implementor needs
+     *
+     * @param request The request as passed from the caller (e.g; CloudFormation) which contains
+     *                additional context to inform the LambdaWrapper itself, and is not needed by the
+     *                handler implementations
+     * @return A converted ResourceHandlerRequest model
+     */
+    protected IterationProviderHandlerRequest<InputT> transform(@Nonnull final IterationProviderWrapperRequest<InputT, CallbackT> request) throws IOException {
+        return new IterationProviderHandlerRequest<>(
+                request.getOperationInfo(),
+                request.getBearerToken(),
+                request.getInputConfiguration(),
+                request.getTemplates()
+        );
+    }
+
+    /**
+     * Handler implementation should implement this method to provide the schema for validation
+     *
+     * @return An InputStream of the resource schema for the provider
+     */
+    protected abstract InputStream provideSchema();
+
+    /**
+     * Implemented by the handler package as the key entry point.
+     */
+    public abstract ProgressEvent<CallbackT> invokeHandler(final AmazonWebServicesClientProxy proxy,
+                                                           final IterationProviderHandlerRequest<InputT> request,
+                                                           final Action action,
+                                                           final CallbackT callbackContext) throws IOException;
+
+    /**
+     * null-safe logger redirect
+     *
+     * @param message A string containing the event to log.
+     */
+    private void log(final String message) {
+        if (this.logger != null) {
+            this.logger.log(String.format("%s\n", message));
+        }
+    }
+
+    protected abstract CallbackAdapter<Collection<Iteration>> getCallbackAdapter();
+
+    protected abstract TypeReference<IterationProviderWrapperRequest<InputT, CallbackT>> getInputTypeReference();
+}

--- a/src/main/java/com/aws/cfn/oasis/model/IterationProviderHandlerRequest.java
+++ b/src/main/java/com/aws/cfn/oasis/model/IterationProviderHandlerRequest.java
@@ -1,0 +1,21 @@
+package com.aws.cfn.oasis.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+
+/**
+ * The model representing the request to the handler itself
+ */
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class IterationProviderHandlerRequest<InputT> {
+    @NonNull private final OperationInfo operationInfo;
+    @NonNull private final String clientRequestToken;
+    @Nullable private final InputT configuration;
+    @NonNull private final Templates templates;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/IterationProviderWrapperRequest.java
+++ b/src/main/java/com/aws/cfn/oasis/model/IterationProviderWrapperRequest.java
@@ -1,0 +1,28 @@
+package com.aws.cfn.oasis.model;
+
+import com.aws.cfn.proxy.Credentials;
+import com.aws.cfn.proxy.RequestContext;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+/**
+ * This represents the request to the Lambda container from the
+ * CloudFormation workflows to the handler for generating template iterations
+ */
+@Value
+@EqualsAndHashCode
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class IterationProviderWrapperRequest<InputT, CallbackT> {
+    @NonNull private final Credentials credentials;
+    @NonNull private final OperationInfo operationInfo;
+    @NonNull private final String bearerToken;
+    @Nullable private final InputT inputConfiguration;
+    @NonNull private final Templates templates;
+    @NonNull private RequestContext<CallbackT> requestContext;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/OperationInfo.java
+++ b/src/main/java/com/aws/cfn/oasis/model/OperationInfo.java
@@ -1,0 +1,24 @@
+package com.aws.cfn.oasis.model;
+
+import com.amazonaws.regions.Region;
+import com.aws.cfn.Action;
+import com.aws.cfn.oasis.model.entity.AccountId;
+import com.aws.cfn.oasis.model.entity.StackId;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * A collection of metadata associated with the current state of the
+ * overall stack operation
+ */
+@Value
+public class OperationInfo {
+    @NonNull private final AccountId accountId;
+    @NonNull private final Action action;
+    @NonNull private final StackId stackId;
+    @NonNull private final Region region;
+    @NonNull private final String stage;
+    private final boolean isRollback;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/ProgressEvent.java
+++ b/src/main/java/com/aws/cfn/oasis/model/ProgressEvent.java
@@ -1,0 +1,13 @@
+package com.aws.cfn.oasis.model;
+
+import com.aws.cfn.oasis.model.nextaction.NextAction;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * Response from the handler implementation itself
+ */
+@Value
+public class ProgressEvent<CallbackT> {
+    @NonNull private final NextAction<CallbackT> nextAction;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/Response.java
+++ b/src/main/java/com/aws/cfn/oasis/model/Response.java
@@ -1,0 +1,54 @@
+package com.aws.cfn.oasis.model;
+
+import com.aws.cfn.oasis.model.iteration.Iteration;
+import com.aws.cfn.proxy.HandlerErrorCode;
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Response<CallbackT> {
+    /**
+     * The bearerToken is used to report progress back to CloudFormation and is passed
+     * back to CloudFormation
+     */
+    private String bearerToken;
+
+    /**
+     * The errorCode is used to report granular failures back to CloudFormation
+     */
+    private HandlerErrorCode errorCode;
+
+    /**
+     * The operationStatus indicates whether the handler has reached a terminal state or
+     * is still computing and requires more time to complete
+     */
+    private OperationStatus operationStatus;
+
+    /**
+     * The handler can (and should) specify a contextual information message which
+     * can be shown to callers to indicate the nature of a progress transition
+     * or callback delay; for example a message indicating "propagating to edge"
+     */
+    private String message;
+
+    /**
+     * The output resource instance populated by a READ/LIST for synchronous results
+     * and by CREATE/UPDATE/DELETE for final response validation/confirmation
+     */
+    private List<Iteration> outputModel;
+
+    /**
+     * In the event of an IN_PROGRESS status, the provider specifies an amount of time
+     * after which CloudFormation will reinvoke the handler if no SUCCESS signal has been
+     * received
+     */
+    private int callbackDelayMinutes;
+
+    /**
+     * In the event of a callback, the provider can supply a context to pass along to its
+     * next invocation
+     */
+    private CallbackT callbackContext;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/Template.java
+++ b/src/main/java/com/aws/cfn/oasis/model/Template.java
@@ -1,0 +1,19 @@
+package com.aws.cfn.oasis.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+/**
+ * Represents a CloudFormation template
+ */
+@EqualsAndHashCode
+@AllArgsConstructor
+public class Template {
+    // TODO object model.
+    @NonNull private final String templateBody;
+
+    public String toString() {
+        return templateBody;
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/Templates.java
+++ b/src/main/java/com/aws/cfn/oasis/model/Templates.java
@@ -1,0 +1,18 @@
+package com.aws.cfn.oasis.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * The bundle of template context to pass along to the handler.  It includes
+ * the previous template and the template of the final target state
+ */
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class Templates {
+    @NonNull private final Template initialTemplate;
+    @NonNull private final Template finalTemplate;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/entity/AccountId.java
+++ b/src/main/java/com/aws/cfn/oasis/model/entity/AccountId.java
@@ -1,0 +1,12 @@
+package com.aws.cfn.oasis.model.entity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A customer's account id
+ */
+public class AccountId extends BaseStringWrapper {
+    public AccountId(@Nonnull final String value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/entity/BaseStringWrapper.java
+++ b/src/main/java/com/aws/cfn/oasis/model/entity/BaseStringWrapper.java
@@ -1,0 +1,41 @@
+package com.aws.cfn.oasis.model.entity;
+
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Base class for strongly typing any different types of strings
+ */
+@Getter
+abstract class BaseStringWrapper {
+    private final String value;
+
+    protected BaseStringWrapper(@Nonnull final String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Value '%s' cannot must be nonnull and non-empty", value));
+        }
+
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o.getClass() != getClass()) return false;
+
+        final BaseStringWrapper that = (BaseStringWrapper) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/entity/LogicalId.java
+++ b/src/main/java/com/aws/cfn/oasis/model/entity/LogicalId.java
@@ -1,0 +1,12 @@
+package com.aws.cfn.oasis.model.entity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Logical id of a resource
+ */
+public class LogicalId extends BaseStringWrapper {
+    public LogicalId(@Nonnull final String value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/entity/StackId.java
+++ b/src/main/java/com/aws/cfn/oasis/model/entity/StackId.java
@@ -1,0 +1,12 @@
+package com.aws.cfn.oasis.model.entity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * The ARN of a stack
+ */
+public class StackId extends BaseStringWrapper {
+    public StackId(@Nonnull final String value) {
+        super(value);
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/iteration/ApplyTemplateIteration.java
+++ b/src/main/java/com/aws/cfn/oasis/model/iteration/ApplyTemplateIteration.java
@@ -1,0 +1,18 @@
+package com.aws.cfn.oasis.model.iteration;
+
+import com.aws.cfn.oasis.model.Template;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Represents the type of iteration that will be applied by updating
+ * the stack to the given template
+ */
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ApplyTemplateIteration implements Iteration {
+    @NonNull private final Template template;
+}

--- a/src/main/java/com/aws/cfn/oasis/model/iteration/Iteration.java
+++ b/src/main/java/com/aws/cfn/oasis/model/iteration/Iteration.java
@@ -1,0 +1,10 @@
+package com.aws.cfn.oasis.model.iteration;
+
+/**
+ * An iteration represents one step along the process of
+ * applying a stack operation.  It will most commonly be applied
+ * by performing an update from the existing template to a new one
+ * but can also be another type of command like renaming a logical id
+ */
+public interface Iteration {
+}

--- a/src/main/java/com/aws/cfn/oasis/model/iteration/RenameLogicalIdIteration.java
+++ b/src/main/java/com/aws/cfn/oasis/model/iteration/RenameLogicalIdIteration.java
@@ -1,0 +1,52 @@
+package com.aws.cfn.oasis.model.iteration;
+
+import com.aws.cfn.oasis.model.entity.LogicalId;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.Value;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Applying this iteration will involve CloudFormation changing the logical ids
+ * of the specified resources both within the template (and all references to them)
+ * as well as within the data stores
+ */
+@Value
+public class RenameLogicalIdIteration implements Iteration {
+    @NonNull private final Map<LogicalId, LogicalId> logicalIdMappings;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final Map<LogicalId, LogicalId> logicalIdMappings = new HashMap<>();
+
+        public Builder logicalIdMapping(@Nonnull final LogicalId oldLogicalId, @Nonnull final LogicalId newLogicalId) {
+            Objects.requireNonNull(oldLogicalId);
+            Objects.requireNonNull(newLogicalId);
+
+            if (oldLogicalId.equals(newLogicalId)) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot map logical id [%s] to itself", oldLogicalId)
+                );
+            }
+
+            logicalIdMappings.put(oldLogicalId, newLogicalId);
+
+            return this;
+        }
+
+        public RenameLogicalIdIteration build() {
+            return new RenameLogicalIdIteration(logicalIdMappings);
+        }
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/NextAction.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/NextAction.java
@@ -1,0 +1,16 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.OperationStatus;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A response from the handler to signal back to CloudFormation what the next
+ * action to take in the operation will be (i.e. fail, continue, etc).
+ */
+public interface NextAction<CallbackT> {
+    @Nonnull OperationStatus getOperationStatus();
+
+    void decorateResponse(@Nonnull final Response<CallbackT> response);
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionApplyIterations.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionApplyIterations.java
@@ -1,0 +1,35 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.oasis.model.iteration.Iteration;
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the response when the iterations are all produced and the handler's work
+ * is done.  It contains the list of iterations that will be applied sequentially during
+ * the update operation
+ */
+@Value
+@EqualsAndHashCode
+public class NextActionApplyIterations<CallbackT> implements NextAction<CallbackT> {
+    @NonNull private final List<Iteration> iterations;
+
+    @Nonnull
+    @Override
+    public OperationStatus getOperationStatus() {
+        return OperationStatus.SUCCESS;
+    }
+
+    @Override
+    public void decorateResponse(@Nonnull final Response<CallbackT> response) {
+        Objects.requireNonNull(response);
+        response.setOutputModel(iterations);
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionDone.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionDone.java
@@ -1,0 +1,27 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Signifies that the handler is done operating (successfully) and the stack operation
+ * is free to continue
+ */
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public final class NextActionDone<CallbackT> extends OptionalStackEventNextAction<CallbackT> {
+
+    public NextActionDone(@Nullable final String message) {
+        super(message);
+    }
+
+    @Nonnull
+    @Override
+    public OperationStatus getOperationStatus() {
+        return OperationStatus.SUCCESS;
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionFail.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionFail.java
@@ -1,0 +1,34 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.HandlerErrorCode;
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Signifies that CloudFormation should fail the current operation and begin rolling back
+ * if appropriate
+ */
+@Value
+public final class NextActionFail<CallbackT> implements NextAction<CallbackT> {
+    @NonNull private final String failureReason;
+    @NonNull private final HandlerErrorCode errorCode;
+
+    @Override
+    public void decorateResponse(@Nonnull final Response<CallbackT> response) {
+        Objects.requireNonNull(response);
+
+        response.setErrorCode(errorCode);
+        response.setMessage(failureReason);
+    }
+
+    @Nonnull
+    @Override
+    public OperationStatus getOperationStatus() {
+        return OperationStatus.FAILED;
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionInProgress.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/NextActionInProgress.java
@@ -1,0 +1,59 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Signifies that the next step to be made by CloudFormation is to reinvoke the handler (unless
+ * a subsequent SUCCESS signal is received before then)
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+public final class NextActionInProgress<CallbackT> extends OptionalStackEventNextAction<CallbackT> {
+    private final int callbackDelayMinutes;
+    @Nullable private final CallbackT callbackContext;
+
+    public NextActionInProgress(final int callbackDelayMinutes, @Nullable final CallbackT callbackContext, @Nullable final String eventMessage) {
+        super(eventMessage);
+        this.callbackContext = callbackContext;
+        this.callbackDelayMinutes = callbackDelayMinutes;
+    }
+
+    public NextActionInProgress(final int callbackDelayMinutes, @Nullable final String message) {
+        this(callbackDelayMinutes, null, message);
+    }
+
+    public NextActionInProgress(final int callbackDelayMinutes, @Nullable final CallbackT callbackContext) {
+        this(callbackDelayMinutes, callbackContext, null);
+    }
+
+    public NextActionInProgress(final int callbackDelayMinutes) {
+        this(callbackDelayMinutes, null, null);
+    }
+
+    public Optional<CallbackT> getCallbackContext() {
+        return Optional.ofNullable(callbackContext);
+    }
+
+    @Override
+    public void decorateResponse(@Nonnull final Response<CallbackT> response) {
+        Objects.requireNonNull(response);
+
+        super.decorateResponse(response);
+        response.setCallbackDelayMinutes(callbackDelayMinutes);
+        if (callbackContext != null) response.setCallbackContext(callbackContext);
+    }
+
+    @Nonnull
+    @Override
+    public OperationStatus getOperationStatus() {
+        return OperationStatus.IN_PROGRESS;
+    }
+}

--- a/src/main/java/com/aws/cfn/oasis/model/nextaction/OptionalStackEventNextAction.java
+++ b/src/main/java/com/aws/cfn/oasis/model/nextaction/OptionalStackEventNextAction.java
@@ -1,0 +1,37 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.OperationStatus;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A generic type of NextAction that has a message associated with it.  This message,
+ * if present, will be published to the stack events
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public abstract class OptionalStackEventNextAction<CallbackT> implements NextAction<CallbackT> {
+    @Nullable private String message;
+
+    public Optional<String> getMessage() {
+        return Optional.ofNullable(message);
+    }
+
+    @Override
+    public void decorateResponse(@Nonnull final Response<CallbackT> response) {
+        Objects.requireNonNull(response);
+        if (message != null) response.setMessage(message);
+    }
+
+    @Nonnull
+    @Override
+    public abstract OperationStatus getOperationStatus();
+}

--- a/src/main/java/com/aws/cfn/oasis/scheduler/CloudWatchScheduler.java
+++ b/src/main/java/com/aws/cfn/oasis/scheduler/CloudWatchScheduler.java
@@ -1,0 +1,140 @@
+package com.aws.cfn.oasis.scheduler;
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.aws.cfn.injection.LambdaModule;
+import com.aws.cfn.oasis.model.IterationProviderWrapperRequest;
+import com.aws.cfn.proxy.RequestContext;
+import com.aws.cfn.scheduler.CronHelper;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import lombok.Data;
+import org.json.JSONObject;
+import software.amazon.awssdk.services.cloudwatchevents.CloudWatchEventsAsyncClient;
+import software.amazon.awssdk.services.cloudwatchevents.model.DeleteRuleRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.PutRuleRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.PutTargetsRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.RemoveTargetsRequest;
+import software.amazon.awssdk.services.cloudwatchevents.model.RuleState;
+import software.amazon.awssdk.services.cloudwatchevents.model.Target;
+import software.amazon.awssdk.utils.StringUtils;
+
+import java.util.UUID;
+
+@Data
+public class CloudWatchScheduler {
+
+    private LambdaLogger logger;
+    private final CronHelper cronHelper;
+    private final CloudWatchEventsAsyncClient client;
+
+    /**
+     * This .ctor provided for Lambda runtime which will not automatically invoke Guice injector
+     */
+    public CloudWatchScheduler() {
+        final Injector injector = Guice.createInjector(new LambdaModule());
+        this.client = injector.getInstance(CloudWatchEventsAsyncClient.class);
+        this.cronHelper = new CronHelper();
+    }
+
+    /**
+     * This .ctor provided for testing
+     */
+    @Inject
+    public CloudWatchScheduler(final CloudWatchEventsAsyncClient client,
+                               final CronHelper cronHelper) {
+        this.client = client;
+        this.cronHelper = cronHelper;
+    }
+
+    /**
+     * Schedule a re-invocation of the executing handler no less than 1 minute from now
+     * @param functionArn       the ARN oft he Lambda function to be invoked
+     * @param minutesFromNow    the minimum minutes from now that the re-invocation will occur. CWE provides only
+     *                          minute-granularity
+     * @param handlerRequest   additional context which the handler can provide itself for re-invocation
+     */
+    public <ResourceT, CallbackT> void rescheduleAfterMinutes(
+                                       final String functionArn,
+                                       final int minutesFromNow,
+                                       final IterationProviderWrapperRequest<ResourceT, CallbackT> handlerRequest) {
+
+        // generate a cron expression; minutes must be a positive integer
+        final String cronRule = this.cronHelper.generateOneTimeCronExpression(Math.max(minutesFromNow, 1));
+
+        final UUID rescheduleId = UUID.randomUUID();
+        final String ruleName = String.format("reinvoke-handler-%s", rescheduleId);
+        final String targetId = String.format("reinvoke-target-%s", rescheduleId);
+
+        // record the CloudWatchEvents objects for cleanup on the callback
+        final RequestContext<CallbackT> requestContext = handlerRequest.getRequestContext();
+        requestContext.setCloudWatchEventsRuleName(ruleName);
+        requestContext.setCloudWatchEventsTargetId(targetId);
+
+        final String jsonRequest = new JSONObject(handlerRequest).toString();
+        this.log(String.format("Scheduling re-invoke at %s (%s)\n", cronRule, rescheduleId));
+
+        final PutRuleRequest putRuleRequest = PutRuleRequest.builder()
+            .name(ruleName)
+            .scheduleExpression(cronRule)
+            .state(RuleState.ENABLED)
+            .build();
+        this.client.putRule(putRuleRequest);
+
+        final Target target = Target.builder()
+            .arn(functionArn)
+            .id(targetId)
+            .input(jsonRequest)
+            .build();
+        final PutTargetsRequest putTargetsRequest = PutTargetsRequest.builder()
+            .targets(target)
+            .rule(putRuleRequest.name())
+            .build();
+        this.client.putTargets(putTargetsRequest);
+    }
+
+    /**
+     * After a re-invocation, the CWE rule which generated the reinvocation should be scrubbed
+     * @param cloudWatchEventsRuleName  the name of the CWE rule which triggered a re-invocation
+     * @param cloudWatchEventsTargetId  the target of the CWE rule which triggered a re-invocation
+     */
+    public void cleanupCloudWatchEvents(final String cloudWatchEventsRuleName,
+                                        final String cloudWatchEventsTargetId) {
+
+        try {
+            if (!StringUtils.isBlank(cloudWatchEventsTargetId)) {
+                final RemoveTargetsRequest removeTargetsRequest = RemoveTargetsRequest.builder()
+                    .ids(cloudWatchEventsTargetId)
+                    .rule(cloudWatchEventsRuleName)
+                    .build();
+                this.client.removeTargets(removeTargetsRequest);
+            }
+        } catch (final Exception e) {
+            this.log(String.format("Error cleaning CloudWatchEvents Target (targetId=%s): %s",
+                    cloudWatchEventsTargetId,
+                    e.getMessage()));
+        }
+        try {
+            if (!StringUtils.isBlank(cloudWatchEventsRuleName)) {
+                final DeleteRuleRequest deleteRuleRequest = DeleteRuleRequest.builder()
+                    .name(cloudWatchEventsRuleName)
+                    .build();
+                this.client.deleteRule(deleteRuleRequest);
+            }
+        } catch (final Exception e) {
+            this.log(String.format("Error cleaning CloudWatchEvents (ruleName=%s): %s",
+                cloudWatchEventsRuleName,
+                e.getMessage()));
+        }
+    }
+
+    /**
+     * null-safe logger redirect
+     * @param message A string containing the event to log.
+     */
+    private void log(final String message) {
+        if (this.logger != null) {
+            this.logger.log(message);
+        }
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/TemplateTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/TemplateTest.java
@@ -1,0 +1,18 @@
+package com.aws.cfn.oasis.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemplateTest {
+    @Test
+    public void testTemplateToString_validInput() {
+        final Template template = new Template("{}");
+        assertEquals("{}", template.toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateTemplate_nullInput_assertConstructorFails() {
+        new Template(null);
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/entity/AccountIdTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/entity/AccountIdTest.java
@@ -1,0 +1,13 @@
+package com.aws.cfn.oasis.model.entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AccountIdTest {
+    @Test
+    public void testGetAccountIdValue_validString_happyCase() {
+        final AccountId accountId = new AccountId("123456");
+        assertEquals("123456", accountId.getValue());
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/entity/BaseStringWrapperTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/entity/BaseStringWrapperTest.java
@@ -1,0 +1,77 @@
+package com.aws.cfn.oasis.model.entity;
+
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.junit.Assert.*;
+
+public class BaseStringWrapperTest {
+
+    @Test
+    public void testDummyStringWrapper_getValue_basicHappyCase() {
+        final DummyStringTest testString = new DummyStringTest("Test");
+        assertEquals("Test", testString.getValue());
+    }
+
+    @Test
+    public void testDummyStringWrapper_toString_basicHappyCase() {
+        final DummyStringTest testString = new DummyStringTest("Test");
+        assertEquals("Test", testString.toString());
+    }
+
+    @Test
+    public void testDummyStringWrapper_equalsSameString_expectTrue() {
+        final DummyStringTest test1 = new DummyStringTest("Test");
+        final DummyStringTest test2 = new DummyStringTest("Test");
+        assertEquals(true, test1.equals(test2));
+        assertEquals(true, test2.equals(test1));
+    }
+
+    @Test
+    public void testDummyStringWrapper_equalsDifferentString_expectFalse() {
+        final DummyStringTest test1 = new DummyStringTest("Test1");
+        final DummyStringTest test2 = new DummyStringTest("Test2");
+        assertEquals(false, test1.equals(test2));
+        assertEquals(false, test2.equals(test1));
+    }
+
+    @Test
+    public void testDummyStringWrapper_hashCodeIdenticalStrings_expectConsistent() {
+        final DummyStringTest test1 = new DummyStringTest("Test");
+        final DummyStringTest test2 = new DummyStringTest("Test");
+        assertEquals(test1.hashCode(), test2.hashCode());
+    }
+
+    @Test
+    public void testDummyStringWrapper_hashCodeDifferentStrings_expectDifferent() {
+        final DummyStringTest test1 = new DummyStringTest("Test1");
+        final DummyStringTest test2 = new DummyStringTest("Test2");
+        assertNotEquals(test1.hashCode(), test2.hashCode());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDummyStringWrapper_nullValue_expectIAEFromConstructor() {
+        new DummyStringTest(null);
+    }
+
+    @Test
+    public void testDummyStringWrapper_equalsDifferentSubclassSameString_expectNotEquals() {
+        final DummyStringTest testType1 = new DummyStringTest("Test");
+        final DifferentDummyStringTest testType2 = new DifferentDummyStringTest("Test");
+        assertEquals(false, testType1.equals(testType2));
+        assertEquals(false, testType2.equals(testType1));
+    }
+
+    private class DummyStringTest extends BaseStringWrapper {
+        private DummyStringTest(@Nonnull final String value) {
+            super(value);
+        }
+    }
+
+    private class DifferentDummyStringTest extends BaseStringWrapper {
+        private DifferentDummyStringTest(@Nonnull final String value) {
+            super(value);
+        }
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/entity/LogicalIdTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/entity/LogicalIdTest.java
@@ -1,0 +1,13 @@
+package com.aws.cfn.oasis.model.entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LogicalIdTest {
+    @Test
+    public void testGetLogicalIdValue_validString_happyCase() {
+        final LogicalId myResource = new LogicalId("MyResource");
+        assertEquals("MyResource", myResource.getValue());
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/entity/StackIdTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/entity/StackIdTest.java
@@ -1,0 +1,16 @@
+package com.aws.cfn.oasis.model.entity;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StackIdTest {
+
+    private static final String STACK_ID = "arn:aws:cloudformation:us-east-1:237885156816:stack/test/62141ec0-fc92-11e7-8395-5044334e0ab3";
+
+    @Test
+    public void testStackIdGetValue_validString_happyCase() {
+        final StackId stackId = new StackId(STACK_ID);
+        assertEquals(STACK_ID, stackId.getValue());
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/iteration/RenameLogicalIdIterationTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/iteration/RenameLogicalIdIterationTest.java
@@ -1,0 +1,62 @@
+package com.aws.cfn.oasis.model.iteration;
+
+import com.aws.cfn.oasis.model.entity.LogicalId;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class RenameLogicalIdIterationTest {
+
+    private static final LogicalId LOGICAL_ID_1 = new LogicalId("Resource1");
+    private static final LogicalId LOGICAL_ID_2 = new LogicalId("Resource2");
+    private static final LogicalId LOGICAL_ID_3 = new LogicalId("Resource3");
+    private static final LogicalId LOGICAL_ID_4 = new LogicalId("Resource4");
+
+    @Test
+    public void testBuildLogicalIdMapping_singleMapping_happyCase() {
+        final RenameLogicalIdIteration iter = RenameLogicalIdIteration.builder().logicalIdMapping(
+                LOGICAL_ID_1, LOGICAL_ID_2
+        ).build();
+
+        final ImmutableMap<LogicalId, LogicalId> expected = ImmutableMap.of(LOGICAL_ID_1, LOGICAL_ID_2);
+        assertEquals(expected, iter.getLogicalIdMappings());
+    }
+
+    @Test
+    public void testBuildLogicalIdMapping_emptyMapping_happyCase() {
+        final RenameLogicalIdIteration iter = RenameLogicalIdIteration.builder().build();
+        assertEquals(Collections.emptyMap(), iter.getLogicalIdMappings());
+    }
+
+    @Test
+    public void testBuildLogicalIdMapping_multipleDifferentMappings_happyCase() {
+        final RenameLogicalIdIteration iter = RenameLogicalIdIteration.builder()
+                                                                      .logicalIdMapping(LOGICAL_ID_1, LOGICAL_ID_2)
+                                                                      .logicalIdMapping(LOGICAL_ID_3, LOGICAL_ID_4)
+                                                                      .build();
+        final ImmutableMap<LogicalId, LogicalId> expected = ImmutableMap.of(
+                LOGICAL_ID_1, LOGICAL_ID_2,
+                LOGICAL_ID_3, LOGICAL_ID_4
+        );
+
+        assertEquals(expected, iter.getLogicalIdMappings());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuildingMapping_nullOldName_expectNPEFromBuilder() {
+        RenameLogicalIdIteration.builder().logicalIdMapping(null, LOGICAL_ID_1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuildingMapping_nullNewName_expectNPEFromBuilder() {
+        RenameLogicalIdIteration.builder().logicalIdMapping(LOGICAL_ID_1, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildingMapping_identicalIds_expectIAEFromBuilder() {
+        RenameLogicalIdIteration.builder().logicalIdMapping(LOGICAL_ID_1, LOGICAL_ID_1);
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionApplyIterationsTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionApplyIterationsTest.java
@@ -1,0 +1,47 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.oasis.model.iteration.Iteration;
+import com.aws.cfn.proxy.OperationStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NextActionApplyIterationsTest {
+
+    @Mock private List<Iteration> iterations;
+    @Mock private Response<Object> response;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateNextAction_nullIterations_expectFailureFromConstructor() {
+        new NextActionApplyIterations<>(null);
+    }
+
+    @Test
+    public void testOperationStatus_expectSuccess() {
+        final NextActionApplyIterations<Object> nextAction = new NextActionApplyIterations<>(iterations);
+        assertEquals(OperationStatus.SUCCESS, nextAction.getOperationStatus());
+    }
+
+    @Test
+    public void testDecorateResponse_validIterationList_expectResponseIncludesIterations() {
+        final NextActionApplyIterations<Object> nextAction = new NextActionApplyIterations<>(iterations);
+
+        nextAction.decorateResponse(response);
+
+        verify(response).setOutputModel(iterations);
+        verifyNoMoreInteractions(response);
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionDoneTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionDoneTest.java
@@ -1,0 +1,58 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.OperationStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NextActionDoneTest {
+
+    @Mock private Response<Object> response;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreateNextAction_noMessage_happyCase() {
+        final NextActionDone<Object> nextAction = new NextActionDone<>();
+
+        assertEquals(false, nextAction.getMessage().isPresent());
+        assertEquals(OperationStatus.SUCCESS, nextAction.getOperationStatus());
+    }
+
+    @Test
+    public void testCreateNextAction_withMessage_happyCase() {
+        final NextActionDone<Object> nextAction = new NextActionDone<>("My message");
+
+        assertEquals(true, nextAction.getMessage().isPresent());
+        assertEquals("My message", nextAction.getMessage().get());
+        assertEquals(OperationStatus.SUCCESS, nextAction.getOperationStatus());
+    }
+
+    @Test
+    public void testDecorateResponse_withMessage_expectMessageInResponse() {
+        final NextActionDone<Object> nextAction = new NextActionDone<>("My message");
+
+        nextAction.decorateResponse(response);
+
+        verify(response).setMessage("My message");
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    public void testDecorateResponse_withoutMessage_expectMessageInResponse() {
+        final NextActionDone<Object> nextAction = new NextActionDone<>();
+
+        nextAction.decorateResponse(response);
+
+        verifyNoMoreInteractions(response);
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionFailTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionFailTest.java
@@ -1,0 +1,40 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import com.aws.cfn.proxy.HandlerErrorCode;
+import com.aws.cfn.proxy.OperationStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NextActionFailTest {
+
+    @Mock private Response<Object> response;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testDecorateResponse_expectMessageAndErrorCodeInResponse() {
+        final NextActionFail<Object> nextAction = new NextActionFail<>("Test", HandlerErrorCode.AccessDenied);
+
+        nextAction.decorateResponse(response);
+
+        verify(response).setErrorCode(HandlerErrorCode.AccessDenied);
+        verify(response).setMessage("Test");
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    public void testOperationStatus_expectStatusFailed() {
+        final NextActionFail<Object> nextAction = new NextActionFail<>("Test", HandlerErrorCode.AccessDenied);
+        assertEquals(OperationStatus.FAILED, nextAction.getOperationStatus());
+    }
+}

--- a/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionInProgressTest.java
+++ b/src/test/java/com/aws/cfn/oasis/model/nextaction/NextActionInProgressTest.java
@@ -1,0 +1,98 @@
+package com.aws.cfn.oasis.model.nextaction;
+
+import com.aws.cfn.oasis.model.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class NextActionInProgressTest {
+
+    private static final Object CALLBACK_CONTEXT = new Object();
+    @Mock private Response<Object> response;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreate_noContextNoMessage_happyCase() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(5);
+
+        assertEquals(5, nextAction.getCallbackDelayMinutes());
+        assertEquals(false, nextAction.getCallbackContext().isPresent());
+        assertEquals(false, nextAction.getMessage().isPresent());
+    }
+
+    @Test
+    public void testCreate_withContextNoMessage_happyCase() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(
+                5,
+                CALLBACK_CONTEXT
+        );
+
+        assertEquals(5, nextAction.getCallbackDelayMinutes());
+        assertEquals(true, nextAction.getCallbackContext().isPresent());
+        assertEquals(false, nextAction.getMessage().isPresent());
+        assertEquals(CALLBACK_CONTEXT, nextAction.getCallbackContext().get());
+    }
+
+    @Test
+    public void testCreate_noContextWithMessage_happyCase() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(
+                5,
+                "Message"
+        );
+
+        assertEquals(5, nextAction.getCallbackDelayMinutes());
+        assertEquals(false, nextAction.getCallbackContext().isPresent());
+        assertEquals(true, nextAction.getMessage().isPresent());
+        assertEquals("Message", nextAction.getMessage().get());
+    }
+
+    @Test
+    public void testCreate_WithContextWithMessage_happyCase() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(
+                5,
+                CALLBACK_CONTEXT,
+                "Message"
+        );
+
+        assertEquals(5, nextAction.getCallbackDelayMinutes());
+        assertEquals(true, nextAction.getCallbackContext().isPresent());
+        assertEquals(true, nextAction.getMessage().isPresent());
+        assertEquals(CALLBACK_CONTEXT, nextAction.getCallbackContext().get());
+        assertEquals("Message", nextAction.getMessage().get());
+    }
+
+    @Test
+    public void testDecorateResponse_withContextAndMessage_expectBothAddedToResponse() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(
+                5,
+                CALLBACK_CONTEXT,
+                "Message"
+        );
+
+        nextAction.decorateResponse(response);
+
+        verify(response).setMessage("Message");
+        verify(response).setCallbackContext(CALLBACK_CONTEXT);
+        verify(response).setCallbackDelayMinutes(5);
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    public void testDecorateResponse_noContextNoMessage_expectOnlyMinutesAddedToResponse() {
+        final NextActionInProgress<Object> nextAction = new NextActionInProgress<>(5);
+
+        nextAction.decorateResponse(response);
+
+        verify(response).setCallbackDelayMinutes(5);
+        verifyNoMoreInteractions(response);
+    }
+}


### PR DESCRIPTION
For the sake of getting a demo up and running and keeping
the change list manageable, this involves a fair bit of duplication
from analogous Uluru code.  This will be consolidated & generified
before anything is merged to master.

Some of the codegen pieces are overridden for now too -- we'll sort out a proper way for these to live side-by-side in another commit

Tested locally with a dummy implementation.  The hooks schema extension isn't ready yet so this doesn't validate against it

This is also only supports TemplateGeneration for now - we'll extend to Execute style hooks soon enough


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.