### PR TITLE
Remove NAME constant from language plugin

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -23,7 +23,6 @@ class JavaArchiveNotFoundError(SysExitRecommendedError):
 
 class JavaLanguagePlugin(LanguagePlugin):
     MODULE_NAME = __name__
-    NAME = "java"
     RUNTIME = "java8"
     ENTRY_POINT = "{}.HandlerWrapper::handleRequest"
     CODE_URI = "./target/{}-1.0-SNAPSHOT.jar"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/158

*Description of changes:* Remove NAME constant from language plugin. It's unused and could have potentially drifted from the entry point name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
