### PR TITLE
Replace Async CloudFormation Client With Sync Client

### DIFF
--- a/src/main/java/com/aws/cfn/LambdaWrapper.java
+++ b/src/main/java/com/aws/cfn/LambdaWrapper.java
@@ -85,7 +85,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         // initialisation skipped if these dependencies were set during injection (in test)
         this.platformCredentialsProvider.setCredentials(platformCredentials);
         if (this.callbackAdapter == null) {
-            this.callbackAdapter = new CloudFormationCallbackAdapter<ResourceT>(this.cloudFormationProvider.get());
+            this.callbackAdapter = new CloudFormationCallbackAdapter<ResourceT>(this.cloudFormationProvider.get(), this.logger);
         }
         if (this.metricsPublisher == null) {
             this.metricsPublisher = new MetricsPublisherImpl(this.cloudWatchProvider.get());

--- a/src/main/java/com/aws/cfn/injection/CloudFormationProvider.java
+++ b/src/main/java/com/aws/cfn/injection/CloudFormationProvider.java
@@ -1,6 +1,8 @@
 package com.aws.cfn.injection;
 
-import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 
 public class CloudFormationProvider extends AmazonWebServicesProvider {
 
@@ -8,9 +10,15 @@ public class CloudFormationProvider extends AmazonWebServicesProvider {
         super(platformCredentialsProvider);
     }
 
-    public CloudFormationAsyncClient get() {
-        return CloudFormationAsyncClient.builder()
-            .credentialsProvider(this.getCredentialsProvider())
-            .build();
+    public CloudFormationClient get() {
+        return CloudFormationClient.builder()
+                .credentialsProvider(this.getCredentialsProvider())
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        //Default Retry Condition of Retry Policy retries on Throttling and ClockSkew Exceptions
+                        .retryPolicy(RetryPolicy.builder()
+                                .numRetries(16)
+                                .build())
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
+++ b/src/main/java/com/aws/cfn/proxy/CloudFormationCallbackAdapter.java
@@ -1,15 +1,20 @@
 package com.aws.cfn.proxy;
 
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import org.json.JSONObject;
-import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.RecordHandlerProgressRequest;
+import software.amazon.awssdk.services.cloudformation.model.RecordHandlerProgressResponse;
 
 public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
 
-    private final CloudFormationAsyncClient client;
+    private final CloudFormationClient client;
 
-    public CloudFormationCallbackAdapter(final CloudFormationAsyncClient client) {
+    private final LambdaLogger logger;
+
+    public CloudFormationCallbackAdapter(final CloudFormationClient client, final LambdaLogger logger) {
         this.client = client;
+        this.logger = logger;
     }
 
     @Override
@@ -32,7 +37,8 @@ public class CloudFormationCallbackAdapter<T> implements CallbackAdapter<T> {
         }
 
         // TODO: be far more fault tolerant, do retries, emit logs and metrics, etc.
-        this.client.recordHandlerProgress(requestBuilder.build());
+        final RecordHandlerProgressResponse response = this.client.recordHandlerProgress(requestBuilder.build());
+        logger.log(String.format("Record Handler Progress with Request Id %s and Request: {%s}" + response.responseMetadata().requestId(), requestBuilder.build().toString()));
     }
 
     private software.amazon.awssdk.services.cloudformation.model.HandlerErrorCode translate(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add logging for Callback Adapter
2. Add retry logic for CFN client 
3.Replace Async CloudFormation Client With Sync Client. 
   * Async Client needs to handler extra logic to handle Interruption Exception and surface error message for failure case.
   * The CFN api we use is sync Api

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
