### PR TITLE
Add @Data and @AllArgsConstructor For POJO template

### DIFF
--- a/python/rpdk/java/templates/POJO.java
+++ b/python/rpdk/java/templates/POJO.java
@@ -6,10 +6,12 @@ import java.util.Map;
 import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class {{ pojo_name|uppercase_first_letter }} {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add @AllArgsConstructor annotation.

- Customized model can extend on generated model for validation and default value setting.
- Construct model for testing.

2. Add @Data annotation

- 'equals' method for comparing two POJOs for immutable update analyzer.
- 'toString' method for clear logging.

The generated POJO will be:
```
@Data
@AllArgsConstructor
public class ResourceModel {
    @JsonProperty("FilterPattern")
    private String filterPattern;

    @JsonProperty("LogGroupName")
    private String logGroupName;

    @JsonProperty("MetricTransformations")
    private List<MetricTransformationProperty> metricTransformations;

    @JsonProperty("FilterName")
    private String filterName;

}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
