### PR TITLE
Adding linting and -Werror to POM

### DIFF
--- a/python/rpdk/java/templates/pom.xml
+++ b/python/rpdk/java/templates/pom.xml
@@ -60,6 +60,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-options,-processing</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
@@ -115,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
*Description of changes:*
Adding linting and -Werror to POM

Intending to lift the bar a bit and reduce codegen errors sneaking in.

Also bumped maven-resources-plugin due to error related to Eclipse IDEs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
