### PR TITLE
Migrate to JUnit 5, AssertJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.11.519</version>
+            <version>1.11.555</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-core -->
         <dependency>
@@ -111,35 +111,42 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.9</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-cloudformation -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudformation</artifactId>
-            <version>1.11.519</version>
+            <version>1.11.555</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.12.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-junit -->
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-junit</artifactId>
-            <version>2.0.0.0</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.0-M1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.23.0</version>
+            <version>2.26.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>2.26.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -173,6 +180,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/test/java/com/aws/cfn/LambdaWrapperTest.java
+++ b/src/test/java/com/aws/cfn/LambdaWrapperTest.java
@@ -16,11 +16,11 @@ import com.aws.cfn.resource.SchemaValidator;
 import com.aws.cfn.resource.exceptions.ValidationException;
 import com.aws.cfn.scheduler.CloudWatchScheduler;
 import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.ArgumentMatchers;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -31,9 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -41,12 +39,13 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LambdaWrapperTest {
 
     private static final String TEST_DATA_BASE_PATH = "src/test/java/com/aws/cfn/data/%s";
@@ -85,7 +84,7 @@ public class LambdaWrapperTest {
         final LambdaLogger lambdaLogger = mock(LambdaLogger.class);
 
         final Context context = mock(Context.class);
-        when(context.getInvokedFunctionArn()).thenReturn("arn:aws:lambda:aws-region:acct-id:function:testHandler:PROD");
+        lenient().when(context.getInvokedFunctionArn()).thenReturn("arn:aws:lambda:aws-region:acct-id:function:testHandler:PROD");
         when(context.getLogger()).thenReturn(lambdaLogger);
 
         return context;
@@ -99,7 +98,7 @@ public class LambdaWrapperTest {
         // a null response is a terminal fault
         wrapper.setInvokeHandlerResponse(null);
 
-        when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
+        lenient().when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
         wrapper.setTransformResponse(resourceHandlerRequest);
 
         try (final InputStream in = loadRequestStream(requestDataPath); final OutputStream out = new ByteArrayOutputStream()) {
@@ -132,11 +131,9 @@ public class LambdaWrapperTest {
                 any(), any());
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}," +
-                               "\"message\":\"Handler failed to provide a response.\"}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}," +
+                "\"message\":\"Handler failed to provide a response.\"}");
         }
     }
 
@@ -176,7 +173,7 @@ public class LambdaWrapperTest {
         pe.setStatus(OperationStatus.FAILED);
         wrapper.setInvokeHandlerResponse(pe);
 
-        when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
+        lenient().when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
         wrapper.setTransformResponse(resourceHandlerRequest);
 
         try (final InputStream in = loadRequestStream(requestDataPath); final OutputStream out = new ByteArrayOutputStream()) {
@@ -209,10 +206,8 @@ public class LambdaWrapperTest {
                 any(), any());
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"message\":\"Custom Fault\"}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"message\":\"Custom Fault\"}");
         }
     }
 
@@ -251,7 +246,7 @@ public class LambdaWrapperTest {
         pe.setStatus(OperationStatus.SUCCESS);
         wrapper.setInvokeHandlerResponse(pe);
 
-        when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
+        lenient().when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
 
         wrapper.setTransformResponse(resourceHandlerRequest);
 
@@ -285,10 +280,8 @@ public class LambdaWrapperTest {
                 any(), any());
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\"}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\"}");
         }
     }
 
@@ -329,7 +322,7 @@ public class LambdaWrapperTest {
         pe.setResourceModel(model);
         wrapper.setInvokeHandlerResponse(pe);
 
-        when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
+        lenient().when(resourceHandlerRequest.getDesiredResourceState()).thenReturn(model);
         wrapper.setTransformResponse(resourceHandlerRequest);
 
         try (final InputStream in = loadRequestStream(requestDataPath); final OutputStream out = new ByteArrayOutputStream()) {
@@ -367,10 +360,8 @@ public class LambdaWrapperTest {
             // TODO
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"IN_PROGRESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"IN_PROGRESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}");
         }
     }
 
@@ -451,10 +442,8 @@ public class LambdaWrapperTest {
             // TODO
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"IN_PROGRESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"IN_PROGRESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}");
         }
     }
 
@@ -530,10 +519,8 @@ public class LambdaWrapperTest {
             // TODO
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}}");
         }
     }
 
@@ -588,10 +575,8 @@ public class LambdaWrapperTest {
             wrapper.handleRequest(in, out, context);
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\",\"resourceModel\":{}}");
         }
     }
 
@@ -606,10 +591,8 @@ public class LambdaWrapperTest {
             wrapper.handleRequest(in, out, context);
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"},\"message\":\"Missing required platform credentials\"}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"},\"message\":\"Missing required platform credentials\"}");
         }
     }
 
@@ -636,10 +619,8 @@ public class LambdaWrapperTest {
             wrapper.handleRequest(in, out, context);
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"SUCCESS\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"}}");
         }
     }
 
@@ -665,10 +646,8 @@ public class LambdaWrapperTest {
             wrapper.handleRequest(in, out, context);
 
             // verify output response
-            assertThat(
-                out.toString(),
-                is(equalTo("{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"},\"errorCode\":\"ServiceException\",\"message\":\"Throttled (Service: null; Status Code: 0; Error Code: null; Request ID: null)\"}"))
-            );
+            assertThat(out.toString()).isEqualTo(
+                "{\"operationStatus\":\"FAILED\",\"bearerToken\":\"123456\",\"resourceModel\":{\"property2\":123,\"property1\":\"abc\"},\"errorCode\":\"ServiceException\",\"message\":\"Throttled (Service: null; Status Code: 0; Error Code: null; Request ID: null)\"}");
         }
     }
 
@@ -714,8 +693,7 @@ public class LambdaWrapperTest {
 
         // invoke the same wrapper instance again to ensure client is refreshed
         context = getLambdaContext();
-        try (InputStream in = loadRequestStream("create.request.with-new-credentials.json"); OutputStream out = new
-                                                                                                               ByteArrayOutputStream()) {
+        try (InputStream in = loadRequestStream("create.request.with-new-credentials.json"); OutputStream out = new ByteArrayOutputStream()) {
             wrapper.handleRequest(in, out, context);
         }
 

--- a/src/test/java/com/aws/cfn/TestContext.java
+++ b/src/test/java/com/aws/cfn/TestContext.java
@@ -1,4 +1,5 @@
 package com.aws.cfn;
+
 import lombok.Data;
 
 @Data

--- a/src/test/java/com/aws/cfn/proxy/AmazonWebServicesClientProxyTest.java
+++ b/src/test/java/com/aws/cfn/proxy/AmazonWebServicesClientProxyTest.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.cloudformation.CloudFormationAsyncClient;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
@@ -15,9 +15,7 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,14 +51,11 @@ public class AmazonWebServicesClientProxyTest {
             eq(null));
 
         // ensure the return type matches
-        assertThat(
-            result,
-            is(equalTo(expectedResult))
-        );
+        assertThat(result).isEqualTo(expectedResult);
     }
 
     @Test
-    public void testInjectCredentialsAndInvokeV2() throws ExecutionException, InterruptedException {
+    public void testInjectCredentialsAndInvokeV2() {
 
         final LambdaLogger lambdaLogger = mock(LambdaLogger.class);
         final Credentials credentials = new Credentials("accessKeyId", "secretAccessKey", "sessionToken");
@@ -98,10 +93,7 @@ public class AmazonWebServicesClientProxyTest {
         verify(client).describeStackEvents(wrappedRequest);
 
         // ensure the return type matches
-        assertThat(
-                result,
-                is(equalTo(expectedResult))
-        );
+        assertThat(result).isEqualTo(expectedResult);
     }
 
     @Test
@@ -143,9 +135,6 @@ public class AmazonWebServicesClientProxyTest {
         verify(client).describeStackEvents(wrappedRequest);
 
         // ensure the return type matches
-        assertThat(
-            result.get(),
-            is(equalTo(expectedResult))
-        );
+        assertThat(result.get()).isEqualTo(expectedResult);
     }
 }

--- a/src/test/java/com/aws/cfn/scheduler/CloudWatchSchedulerTest.java
+++ b/src/test/java/com/aws/cfn/scheduler/CloudWatchSchedulerTest.java
@@ -6,12 +6,11 @@ import com.aws.cfn.TestModel;
 import com.aws.cfn.injection.CloudWatchEventsProvider;
 import com.aws.cfn.proxy.HandlerRequest;
 import com.aws.cfn.proxy.RequestContext;
-import junit.framework.TestCase;
 import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.cloudwatchevents.CloudWatchEventsClient;
 import software.amazon.awssdk.services.cloudwatchevents.model.DeleteRuleRequest;
 import software.amazon.awssdk.services.cloudwatchevents.model.RemoveTargetsRequest;
@@ -28,8 +27,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CloudWatchSchedulerTest extends TestCase {
+@ExtendWith(MockitoExtension.class)
+public class CloudWatchSchedulerTest {
 
     @Mock
     private LambdaLogger logger;

--- a/src/test/java/com/aws/cfn/scheduler/CronHelperTest.java
+++ b/src/test/java/com/aws/cfn/scheduler/CronHelperTest.java
@@ -1,15 +1,13 @@
 package com.aws.cfn.scheduler;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,9 +24,7 @@ public class CronHelperTest {
         final CronHelper cronHelper = new CronHelper(mockClockInASock);
 
         assertThat(
-            cronHelper.generateOneTimeCronExpression(5),
-            is(equalTo("cron(46 13 30 10 ? 2018)"))
-        );
+            cronHelper.generateOneTimeCronExpression(5)).isEqualTo("cron(46 13 30 10 ? 2018)");
     }
 
     @Test
@@ -42,9 +38,7 @@ public class CronHelperTest {
         final CronHelper cronHelper = new CronHelper(mockClockInASock);
 
         assertThat(
-            cronHelper.generateOneTimeCronExpression(3),
-            is(equalTo("cron(3 0 31 10 ? 2018)"))
-        );
+            cronHelper.generateOneTimeCronExpression(3)).isEqualTo("cron(3 0 31 10 ? 2018)");
     }
 
     @Test
@@ -58,8 +52,6 @@ public class CronHelperTest {
         final CronHelper cronHelper = new CronHelper(mockClockInASock);
 
         assertThat(
-            cronHelper.generateOneTimeCronExpression(5),
-            is(equalTo("cron(2 0 1 1 ? 2019)"))
-        );
+            cronHelper.generateOneTimeCronExpression(5)).isEqualTo("cron(2 0 1 1 ? 2019)");
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Wrapper only: bump some dependencies, migrate to JUnit 5, and re-write asserts with [AssertJ](https://joel-costigliola.github.io/assertj/), which we've found to be easier to use since matchers can be autocompleted by the IDE. Mockito also requires all mocks to be called by default now; I've marked the ones where that isn't the case with `lenient()`.

Note: doesn't touch the auto-generated output,  that would be a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
