### PR TITLE
Allows metric publishing faults to be non-fatal

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
+++ b/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
@@ -103,7 +103,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         this.callbackAdapter.refreshClient();
 
         if (this.metricsPublisher == null) {
-            this.metricsPublisher = new MetricsPublisherImpl(this.cloudWatchProvider);
+            this.metricsPublisher = new MetricsPublisherImpl(this.cloudWatchProvider, this.logger);
         }
         this.metricsPublisher.refreshClient();
 


### PR DESCRIPTION
*Description of changes:*

Allows metric publishing faults to be non-fatal. During testing I observed that with broken credentials, a failed Metric push would cause the entire handler invocation to fail. This seems unnecessarily intolerant for such a problem. We'd be able to observe missing metrics as a fault and respond as needed; this shouldn't impact provisioning actions however.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
