### PR TITLE
[Issue #80] Fixes lenient model deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,17 +215,17 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.5</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.6</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.6</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/com/amazonaws/cloudformation/resource/Serializer.java
+++ b/src/main/java/com/amazonaws/cloudformation/resource/Serializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.JSONObject;
 import java.io.IOException;
-import java.util.Map;
 
 public class Serializer {
 
@@ -20,7 +19,7 @@ public class Serializer {
 
     /**
      * Configures the specified ObjectMapper with the (de)serialization behaviours we want gto enforce
-     * @param objectMapper
+     * @param objectMapper  ObjectMapper instance to configure
      */
     private void configureObjectMapper(final ObjectMapper objectMapper) {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -37,20 +36,6 @@ public class Serializer {
         }
 
         return new JSONObject(objectMapper.writeValueAsString(modelObject));
-    }
-
-    public Map<String, Object> serializeToMap(final Object modelObject) {
-        return objectMapper.convertValue(modelObject, new TypeReference<Map<String,Object>>() {});
-    }
-
-    public <T> T deserialize(final Object o,
-                             final Class<T> valueType) throws IOException {
-        return deserialize(objectMapper.writeValueAsString(o), valueType);
-    }
-
-    public <T> T deserialize(final String s,
-                             final Class<T> valueType) throws IOException {
-        return this.objectMapper.readValue(s, valueType);
     }
 
     public <T> T deserialize(final String s,

--- a/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
+++ b/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
@@ -51,7 +51,7 @@ public class WrapperOverride extends LambdaWrapper<TestModel, TestContext> {
     @Override
     public InputStream provideResourceSchema() {
         return new ByteArrayInputStream(
-            "{ \"properties\": { \"propertyA\": { \"type\": \"string\" } } }".getBytes(Charset.forName("UTF8")));
+            "{ \"properties\": { \"property1\": { \"type\": \"string\" }, \"property2\": { \"type\": \"integer\" } }, \"additionalProperties\": false }".getBytes(Charset.forName("UTF8")));
     }
 
     @Override

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-model-fields.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-model-fields.json
@@ -1,0 +1,38 @@
+{
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "responseEndpoint": "cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestContext": {},
+    "requestData": {
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "platformCredentials": {
+            "accessKeyId": "32IEHAHFIAG538KYASAI",
+            "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
+            "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
+        },
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {
+            "property1": "abc",
+            "property2": 123,
+            "fieldCausesValidationError": "DONOTIGNORE"
+        },
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
+        }
+    },
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-request-fields.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-request-fields.json
@@ -1,0 +1,39 @@
+{
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "thisFieldShouldBeIgnored": "IGNOREME",
+    "responseEndpoint": "cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestContext": {},
+    "requestData": {
+        "thisFieldShouldAlsoBeIgnored": "IGNOREME",
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "platformCredentials": {
+            "accessKeyId": "32IEHAHFIAG538KYASAI",
+            "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
+            "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
+        },
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {
+            "property1": "abc",
+            "property2": 123
+        },
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
+        }
+    },
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/src/test/java/com/amazonaws/cloudformation/proxy/CloudFormationCallbackAdapterTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/proxy/CloudFormationCallbackAdapterTest.java
@@ -1,0 +1,69 @@
+package com.amazonaws.cloudformation.proxy;
+
+import com.amazonaws.cloudformation.TestModel;
+import com.amazonaws.cloudformation.injection.CloudFormationProvider;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationResponseMetadata;
+import software.amazon.awssdk.services.cloudformation.model.RecordHandlerProgressRequest;
+import software.amazon.awssdk.services.cloudformation.model.RecordHandlerProgressResponse;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static software.amazon.awssdk.services.cloudformation.model.HandlerErrorCode.INVALID_REQUEST;
+import static software.amazon.awssdk.services.cloudformation.model.OperationStatus.FAILED;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudFormationCallbackAdapterTest {
+
+    @Mock
+    private CloudFormationProvider cloudFormationProvider;
+
+    @Mock
+    private LambdaLogger lambdaLogger;
+
+    @Test
+    public void testReportProgress() {
+        final CloudFormationClient client = mock(CloudFormationClient.class);
+
+        final RecordHandlerProgressResponse response = mock(RecordHandlerProgressResponse.class);
+        final CloudFormationResponseMetadata responseMetadata = mock(CloudFormationResponseMetadata.class);
+        lenient().when(responseMetadata.requestId()).thenReturn(UUID.randomUUID().toString());
+        lenient().when(response.responseMetadata()).thenReturn(responseMetadata);
+
+        lenient().when(cloudFormationProvider.get()).thenReturn(client);
+
+        lenient().when(client.recordHandlerProgress(any(RecordHandlerProgressRequest.class)))
+            .thenReturn(response);
+
+        final CloudFormationCallbackAdapter<TestModel> adapter = new CloudFormationCallbackAdapter<>(cloudFormationProvider, lambdaLogger);
+        adapter.refreshClient();
+
+        adapter.reportProgress(
+            "bearer-token",
+            HandlerErrorCode.InvalidRequest,
+            OperationStatus.FAILED,
+            null,
+            "some error");
+
+        final ArgumentCaptor<RecordHandlerProgressRequest> argument =
+            ArgumentCaptor.forClass(RecordHandlerProgressRequest.class);
+        verify(client).recordHandlerProgress(argument.capture());
+        assertThat(argument.getValue()).isNotNull();
+        assertThat(argument.getValue().bearerToken()).isEqualTo("bearer-token");
+        assertThat(argument.getValue().errorCode()).isEqualTo(INVALID_REQUEST);
+        assertThat(argument.getValue().operationStatus()).isEqualTo(FAILED);
+        assertThat(argument.getValue().resourceModel()).isNull();
+        assertThat(argument.getValue().statusMessage()).isEqualTo("some error");
+    }
+}

--- a/src/test/java/com/amazonaws/cloudformation/resource/SerializerTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/resource/SerializerTest.java
@@ -1,0 +1,190 @@
+package com.amazonaws.cloudformation.resource;
+
+import com.amazonaws.cloudformation.Action;
+import com.amazonaws.cloudformation.TestContext;
+import com.amazonaws.cloudformation.TestModel;
+import com.amazonaws.cloudformation.proxy.HandlerRequest;
+import com.amazonaws.cloudformation.proxy.RequestContext;
+import com.amazonaws.cloudformation.proxy.RequestData;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializerTest {
+
+    private static final String TEST_DATA_BASE_PATH = "src/test/java/com/amazonaws/cloudformation/data/%s";
+
+    private final TypeReference<HandlerRequest<TestModel, TestContext>> typeReference =
+        new TypeReference<HandlerRequest<TestModel, TestContext>>() { };
+
+    public static String loadRequestJson(final String fileName) throws IOException {
+        final File file = new File(String.format(TEST_DATA_BASE_PATH, fileName));
+
+        try {
+            final InputStream inputStream = new FileInputStream(file);
+            return IOUtils.toString(inputStream, "UTF-8");
+        } catch (final FileNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Test
+    public void testDeserialize_AccuratePayload() throws IOException {
+        final Serializer s = new Serializer();
+
+        final String in = loadRequestJson("create.request.json");
+
+        final HandlerRequest<TestModel, TestContext> r = s.deserialize(in, typeReference);
+
+        assertThat(r).isNotNull();
+        assertThat(r.getAction()).isEqualTo(Action.CREATE);
+        assertThat(r.getAwsAccountId()).isEqualTo("123456789012");
+        assertThat(r.getBearerToken()).isEqualTo("123456");
+        assertThat(r.getRegion()).isEqualTo("us-east-1");
+        assertThat(r.getRequestContext()).isNotNull();
+        assertThat(r.getRequestData()).isNotNull();
+        assertThat(r.getResponseEndpoint()).isEqualTo("cloudformation.us-west-2.amazonaws.com");
+        assertThat(r.getResourceType()).isEqualTo("AWS::Test::TestModel");
+        assertThat(r.getResourceTypeVersion()).isEqualTo("1.0");
+        assertThat(r.getStackId()).isEqualTo("arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968");
+
+        final RequestContext<TestContext> requestContext = r.getRequestContext();
+        assertThat(requestContext.getCloudWatchEventsRuleName()).isNull();
+        assertThat(requestContext.getCloudWatchEventsTargetId()).isNull();
+        assertThat(requestContext.getInvocation()).isEqualTo(0);
+        assertThat(requestContext.getCallbackContext()).isNull();
+
+        final RequestData<TestModel> requestData = r.getRequestData();
+        assertThat(requestData.getCallerCredentials()).isNotNull();
+        assertThat(requestData.getCallerCredentials().getAccessKeyId()).isEqualTo("IASAYK835GAIFHAHEI23");
+        assertThat(requestData.getCallerCredentials().getSecretAccessKey()).isEqualTo("66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0");
+        assertThat(requestData.getCallerCredentials().getSessionToken()).isEqualTo("lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg");
+        assertThat(requestData.getPlatformCredentials()).isNotNull();
+        assertThat(requestData.getPlatformCredentials().getAccessKeyId()).isEqualTo("32IEHAHFIAG538KYASAI");
+        assertThat(requestData.getPlatformCredentials().getSecretAccessKey()).isEqualTo("0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66");
+        assertThat(requestData.getPlatformCredentials().getSessionToken()).isEqualTo("gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal");
+        assertThat(requestData.getLogicalResourceId()).isEqualTo("myBucket");
+        assertThat(requestData.getPreviousStackTags()).hasSize(1);
+        assertThat(requestData.getPreviousStackTags().get("tag1")).isEqualTo("def");
+        assertThat(requestData.getStackTags()).hasSize(1);
+        assertThat(requestData.getStackTags().get("tag1")).isEqualTo("abc");
+        assertThat(requestData.getSystemTags()).hasSize(1);
+        assertThat(requestData.getSystemTags().get("aws:cloudformation:stack-id")).isEqualTo("SampleStack");
+
+        assertThat(requestData.getPreviousResourceProperties()).isNull();
+        assertThat(requestData.getResourceProperties()).isNotNull();
+        assertThat(requestData.getResourceProperties().getProperty1()).isEqualTo("abc");
+        assertThat(requestData.getResourceProperties().getProperty2()).isEqualTo(123);
+    }
+
+    @Test
+    public void testDeserialize_ExtranousRequestFields_AreIncluded() throws IOException {
+        final Serializer s = new Serializer();
+
+        // serialization is intentionally loose to minimise disruption on interface changes,
+        // however but model validation will consider raw payload
+        final String in = loadRequestJson("create.request.with-extraneous-request-fields.json");
+
+        final HandlerRequest<TestModel, TestContext> r = s.deserialize(in, typeReference);
+
+        assertThat(r).isNotNull();
+        assertThat(r.getAction()).isEqualTo(Action.CREATE);
+        assertThat(r.getAwsAccountId()).isEqualTo("123456789012");
+        assertThat(r.getBearerToken()).isEqualTo("123456");
+        assertThat(r.getRegion()).isEqualTo("us-east-1");
+        assertThat(r.getRequestContext()).isNotNull();
+        assertThat(r.getRequestData()).isNotNull();
+        assertThat(r.getResponseEndpoint()).isEqualTo("cloudformation.us-west-2.amazonaws.com");
+        assertThat(r.getResourceType()).isEqualTo("AWS::Test::TestModel");
+        assertThat(r.getResourceTypeVersion()).isEqualTo("1.0");
+        assertThat(r.getStackId()).isEqualTo("arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968");
+
+        final RequestContext<TestContext> requestContext = r.getRequestContext();
+        assertThat(requestContext.getCloudWatchEventsRuleName()).isNull();
+        assertThat(requestContext.getCloudWatchEventsTargetId()).isNull();
+        assertThat(requestContext.getInvocation()).isEqualTo(0);
+        assertThat(requestContext.getCallbackContext()).isNull();
+
+        final RequestData<TestModel> requestData = r.getRequestData();
+        assertThat(requestData.getCallerCredentials()).isNotNull();
+        assertThat(requestData.getCallerCredentials().getAccessKeyId()).isEqualTo("IASAYK835GAIFHAHEI23");
+        assertThat(requestData.getCallerCredentials().getSecretAccessKey()).isEqualTo("66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0");
+        assertThat(requestData.getCallerCredentials().getSessionToken()).isEqualTo("lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg");
+        assertThat(requestData.getPlatformCredentials()).isNotNull();
+        assertThat(requestData.getPlatformCredentials().getAccessKeyId()).isEqualTo("32IEHAHFIAG538KYASAI");
+        assertThat(requestData.getPlatformCredentials().getSecretAccessKey()).isEqualTo("0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66");
+        assertThat(requestData.getPlatformCredentials().getSessionToken()).isEqualTo("gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal");
+        assertThat(requestData.getLogicalResourceId()).isEqualTo("myBucket");
+        assertThat(requestData.getPreviousStackTags()).hasSize(1);
+        assertThat(requestData.getPreviousStackTags().get("tag1")).isEqualTo("def");
+        assertThat(requestData.getStackTags()).hasSize(1);
+        assertThat(requestData.getStackTags().get("tag1")).isEqualTo("abc");
+        assertThat(requestData.getSystemTags()).hasSize(1);
+        assertThat(requestData.getSystemTags().get("aws:cloudformation:stack-id")).isEqualTo("SampleStack");
+
+        assertThat(requestData.getPreviousResourceProperties()).isNull();
+        assertThat(requestData.getResourceProperties()).isNotNull();
+        assertThat(requestData.getResourceProperties().getProperty1()).isEqualTo("abc");
+        assertThat(requestData.getResourceProperties().getProperty2()).isEqualTo(123);
+    }
+
+    @Test
+    public void testDeserialize_ExtranousModelFields_AreAllowed() throws IOException {
+        final Serializer s = new Serializer();
+
+        // serialization is intentionally loose to minimise disruption on interface changes,
+        // however but model validation will consider raw payload
+        final String in = loadRequestJson("create.request.with-extraneous-model-fields.json");
+
+        final HandlerRequest<TestModel, TestContext> r = s.deserialize(in, typeReference);
+
+        assertThat(r).isNotNull();
+        assertThat(r.getAction()).isEqualTo(Action.CREATE);
+        assertThat(r.getAwsAccountId()).isEqualTo("123456789012");
+        assertThat(r.getBearerToken()).isEqualTo("123456");
+        assertThat(r.getRegion()).isEqualTo("us-east-1");
+        assertThat(r.getRequestContext()).isNotNull();
+        assertThat(r.getRequestData()).isNotNull();
+        assertThat(r.getResponseEndpoint()).isEqualTo("cloudformation.us-west-2.amazonaws.com");
+        assertThat(r.getResourceType()).isEqualTo("AWS::Test::TestModel");
+        assertThat(r.getResourceTypeVersion()).isEqualTo("1.0");
+        assertThat(r.getStackId()).isEqualTo("arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968");
+
+        final RequestContext<TestContext> requestContext = r.getRequestContext();
+        assertThat(requestContext.getCloudWatchEventsRuleName()).isNull();
+        assertThat(requestContext.getCloudWatchEventsTargetId()).isNull();
+        assertThat(requestContext.getInvocation()).isEqualTo(0);
+        assertThat(requestContext.getCallbackContext()).isNull();
+
+        final RequestData<TestModel> requestData = r.getRequestData();
+        assertThat(requestData.getCallerCredentials()).isNotNull();
+        assertThat(requestData.getCallerCredentials().getAccessKeyId()).isEqualTo("IASAYK835GAIFHAHEI23");
+        assertThat(requestData.getCallerCredentials().getSecretAccessKey()).isEqualTo("66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0");
+        assertThat(requestData.getCallerCredentials().getSessionToken()).isEqualTo("lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg");
+        assertThat(requestData.getPlatformCredentials()).isNotNull();
+        assertThat(requestData.getPlatformCredentials().getAccessKeyId()).isEqualTo("32IEHAHFIAG538KYASAI");
+        assertThat(requestData.getPlatformCredentials().getSecretAccessKey()).isEqualTo("0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66");
+        assertThat(requestData.getPlatformCredentials().getSessionToken()).isEqualTo("gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal");
+        assertThat(requestData.getLogicalResourceId()).isEqualTo("myBucket");
+        assertThat(requestData.getPreviousStackTags()).hasSize(1);
+        assertThat(requestData.getPreviousStackTags().get("tag1")).isEqualTo("def");
+        assertThat(requestData.getStackTags()).hasSize(1);
+        assertThat(requestData.getStackTags().get("tag1")).isEqualTo("abc");
+        assertThat(requestData.getSystemTags()).hasSize(1);
+        assertThat(requestData.getSystemTags().get("aws:cloudformation:stack-id")).isEqualTo("SampleStack");
+
+        assertThat(requestData.getPreviousResourceProperties()).isNull();
+        assertThat(requestData.getResourceProperties()).isNotNull();
+        assertThat(requestData.getResourceProperties().getProperty1()).isEqualTo("abc");
+        assertThat(requestData.getResourceProperties().getProperty2()).isEqualTo(123);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #80

*Description of changes:*

In order to minimise impact from caller errors or interface changes, payload deserialization is intentionally lenient on unknown additional fields. However, this also led to extraneous keys being dropped from incoming model payloads, which prevented these being surfaced as validation errors when the 'cleaned' model was inspected against schema. This change ensures that the raw payload from the caller is used for validation, rather than the post-deserialization payload.

This change also improves some other tests and fixes the test schema for this test case.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
