### PR TITLE
Use default name for SAM template

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -82,9 +82,9 @@ class JavaLanguagePlugin(LanguagePlugin):
         project.safewrite(path, contents)
 
         # CloudFormation/SAM template for handler lambda
-        path = project.root / "Handler.yaml"
+        path = project.root / "template.yml"
         LOG.debug("Writing SAM template: %s", path)
-        template = self.env.get_template("Handler.yaml")
+        template = self.env.get_template("template.yml")
         contents = template.render(
             resource_type=project.type_name,
             handler_params={

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -38,11 +38,11 @@ def test_initialize(project):
     actual_group_id = pom_tree.find("maven:groupId", namespace)
     expected_group_id = "com.aws.foo.{}".format(RESOURCE.lower())
     assert actual_group_id.text == expected_group_id
-    path = project.root / "Handler.yaml"
+    path = project.root / "template.yml"
     with path.open("r", encoding="utf-8") as f:
         template = yaml.safe_load(f)
 
-    handler_properties = template["Resources"]["ResourceHandler"]["Properties"]
+    handler_properties = template["Resources"]["TypeFunction"]["Properties"]
 
     code_uri = "./target/{}-handler-1.0-SNAPSHOT.jar".format(project.hypenated_name)
     assert handler_properties["CodeUri"] == code_uri


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/240

*Description of changes:* I've renamed the file to `template.yml`, which is the default name SAM CLI assigns. This means the template name doesn't need to be passed anymore, so e.g. `sam validate` and `sam local start-lambda` just work. See also https://github.com/aws-cloudformation/aws-cloudformation-rpdk/pull/252

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
