### PR TITLE
Log and metrics delivery to resource owner (#107)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>cloudwatchevents</artifactId>
             <version>2.5.11</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
+            <version>2.5.66</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
         <dependency>

--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -47,7 +47,7 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
         if (!handlers.containsKey(action))
             throw new RuntimeException("Unknown action " + actionName);
 
-        final LoggerProxy loggerProxy = new LoggerProxy(this.logger);
+        final LoggerProxy loggerProxy = new LoggerProxy(this.platformLambdaLogger, this.resourceOwnerEventsLogger);
 
         final BaseHandler<CallbackContext> handler = handlers.get(action);
 

--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchEventsLogProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchEventsLogProvider.java
@@ -1,0 +1,24 @@
+package com.amazonaws.cloudformation.injection;
+
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+
+public class CloudWatchEventsLogProvider extends AmazonWebServicesProvider {
+
+    public CloudWatchEventsLogProvider(final CredentialsProvider credentialsProvider) {
+        super(credentialsProvider);
+    }
+
+    public CloudWatchLogsClient get() {
+        return CloudWatchLogsClient.builder()
+                .credentialsProvider(this.getCredentialsProvider())
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        //Default Retry Condition of Retry Policy retries on Throttling and ClockSkew Exceptions
+                        .retryPolicy(RetryPolicy.builder()
+                                .numRetries(16)
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/amazonaws/cloudformation/injection/ResourceOwnerLoggingCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/ResourceOwnerLoggingCredentialsProvider.java
@@ -1,0 +1,20 @@
+package com.amazonaws.cloudformation.injection;
+
+import com.amazonaws.cloudformation.proxy.Credentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+public class ResourceOwnerLoggingCredentialsProvider implements CredentialsProvider {
+
+    private AwsSessionCredentials awsSessionCredentials;
+
+    public AwsSessionCredentials get() {
+        return this.awsSessionCredentials;
+    }
+
+    public void setCredentials(final Credentials credentials) {
+        this.awsSessionCredentials = AwsSessionCredentials.create(
+            credentials.getAccessKeyId(),
+            credentials.getSecretAccessKey(),
+            credentials.getSessionToken());
+    }
+}

--- a/src/main/java/com/amazonaws/cloudformation/logs/LogPublisher.java
+++ b/src/main/java/com/amazonaws/cloudformation/logs/LogPublisher.java
@@ -1,0 +1,6 @@
+package com.amazonaws.cloudformation.logs;
+
+public interface LogPublisher {
+    void publishLogEvent(final String messageToLog);
+    void initializeLoggingConditions();
+}

--- a/src/main/java/com/amazonaws/cloudformation/logs/LogPublisherImpl.java
+++ b/src/main/java/com/amazonaws/cloudformation/logs/LogPublisherImpl.java
@@ -1,0 +1,105 @@
+package com.amazonaws.cloudformation.logs;
+
+import com.amazonaws.cloudformation.injection.CloudWatchEventsLogProvider;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogGroupRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogStreamRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class LogPublisherImpl implements LogPublisher {
+
+    private final CloudWatchEventsLogProvider cloudWatchEventsLogProvider;
+
+    private CloudWatchLogsClient cloudWatchLogsClient;
+    private String logGroupName;
+    private String logStreamName;
+    private LambdaLogger platformLambdaLogger;
+    private boolean skipLogging = false;
+
+    public LogPublisherImpl(final CloudWatchEventsLogProvider cloudWatchEventsLogProvider,
+                            final String logGroupName,
+                            final LambdaLogger platformLambdaLogger) {
+        this.cloudWatchEventsLogProvider = cloudWatchEventsLogProvider;
+        this.logGroupName = logGroupName;
+        this.platformLambdaLogger = platformLambdaLogger;
+    }
+
+    @Override
+    public void initializeLoggingConditions() {
+        try {
+            refreshClient();
+            createLogGroupIfNotExist();
+            this.logStreamName = createLogStream();
+        } catch (Throwable ex) {
+            skipLogging = true;
+            platformLambdaLogger.log("Initializing logging group setting failed with error: " + ex.toString());
+        }
+    }
+
+    private void createLogGroupIfNotExist() {
+        if (!doesLogGroupExist()) {
+            createLogGroup();
+        }
+    }
+
+    private boolean doesLogGroupExist() {
+        final DescribeLogGroupsResponse response = cloudWatchLogsClient.describeLogGroups(
+                DescribeLogGroupsRequest.builder().logGroupNamePrefix(logGroupName).build());
+        final Boolean logGroupExists =
+                response.logGroups().stream().filter(
+                        logGroup -> logGroup.logGroupName().equals(logGroupName)).findAny().isPresent();
+
+        platformLambdaLogger.log(String.format(
+                "Log group with name %s does%s exist in resource owner account.",
+                logGroupName,
+                logGroupExists ? "": " not"));
+        return logGroupExists;
+    }
+
+    private void createLogGroup() {
+        platformLambdaLogger.log(String.format(
+                "Creating Log group with name %s in resource owner account.", logGroupName));
+        cloudWatchLogsClient.createLogGroup(CreateLogGroupRequest.builder().logGroupName(logGroupName).build());
+    }
+
+    private String createLogStream() {
+        final String logStreamName = UUID.randomUUID().toString();
+        platformLambdaLogger.log(String.format(
+                "Creating Log stream with name %s for log group %s.", logStreamName, logGroupName));
+        cloudWatchLogsClient.createLogStream(CreateLogStreamRequest.builder()
+                .logGroupName(logGroupName)
+                .logStreamName(logStreamName).build());
+        return logStreamName;
+    }
+
+    private void refreshClient() {
+        if (this.cloudWatchLogsClient == null) {
+            this.cloudWatchLogsClient = cloudWatchEventsLogProvider.get();
+        }
+    }
+
+    @Override
+    public void publishLogEvent(final String messageToLog) {
+        try {
+            if (skipLogging) {
+                return;
+            }
+            cloudWatchLogsClient.putLogEvents(PutLogEventsRequest.builder()
+                    .logGroupName(logGroupName)
+                    .logStreamName(logStreamName)
+                    .logEvents(InputLogEvent.builder().message(messageToLog).timestamp(new Date().getTime()).build())
+                    .build());
+        } catch (final Exception e) {
+            platformLambdaLogger.log(String.format(
+                    "An error occurred while putting log events [%s] to resource owner account, with error: %s",
+                    messageToLog, e.toString()));
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/cloudformation/metrics/MetricsPublisherImpl.java
+++ b/src/main/java/com/amazonaws/cloudformation/metrics/MetricsPublisherImpl.java
@@ -2,6 +2,7 @@ package com.amazonaws.cloudformation.metrics;
 
 import com.amazonaws.cloudformation.Action;
 import com.amazonaws.cloudformation.injection.CloudWatchProvider;
+import com.amazonaws.cloudformation.logs.LogPublisher;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
@@ -17,23 +18,33 @@ import java.util.Map;
 
 public class MetricsPublisherImpl implements MetricsPublisher {
 
-    private final CloudWatchProvider cloudWatchProvider;
+    private final CloudWatchProvider platformCloudWatchProvider;
+    private final CloudWatchProvider resourceOwnerCloudWatchProvider;
 
-    private final LambdaLogger logger;
+    private final LambdaLogger platformLambdaLogger;
+    private final LogPublisher resourceOwnerEventsLogger;
 
-    private CloudWatchClient client;
+    private CloudWatchClient platformCloudWatchClient;
+    private CloudWatchClient resourceOwnerCloudWatchClient;
 
     private String resourceNamespace;
     private String resourceTypeName;
 
-    public MetricsPublisherImpl(final CloudWatchProvider cloudWatchProvider,
-                                final LambdaLogger logger) {
-        this.cloudWatchProvider = cloudWatchProvider;
-        this.logger = logger;
+    public MetricsPublisherImpl(final CloudWatchProvider platformCloudWatchProvider,
+                                final CloudWatchProvider resourceOwnerCloudWatchProvider,
+                                final LogPublisher resourceOwnerEventsLogger,
+                                final LambdaLogger platformLambdaLogger) {
+        this.platformCloudWatchProvider = platformCloudWatchProvider;
+        this.resourceOwnerCloudWatchProvider = resourceOwnerCloudWatchProvider;
+        this.resourceOwnerEventsLogger = resourceOwnerEventsLogger;
+        this.platformLambdaLogger = platformLambdaLogger;
     }
 
     public void refreshClient() {
-        this.client = cloudWatchProvider.get();
+        this.platformCloudWatchClient = platformCloudWatchProvider.get();
+        if (resourceOwnerCloudWatchProvider != null) {
+            this.resourceOwnerCloudWatchClient = resourceOwnerCloudWatchProvider.get();
+        }
     }
 
     public String getResourceTypeName() {
@@ -118,9 +129,25 @@ public class MetricsPublisherImpl implements MetricsPublisher {
             .build();
 
         try {
-            client.putMetricData(putMetricDataRequest);
+            platformCloudWatchClient.putMetricData(putMetricDataRequest);
+            if (resourceOwnerCloudWatchClient != null) {
+                resourceOwnerCloudWatchClient.putMetricData(putMetricDataRequest);
+            }
         } catch (final Exception e) {
-            logger.log(String.format("An error occurred while publishing metrics: %s", e.getMessage()));
+            log(String.format("An error occurred while publishing metrics: %s", e.getMessage()));
+        }
+    }
+
+    /**
+     * null-safe platformLambdaLogger redirect
+     * @param message A string containing the event to log.
+     */
+    private void log(final String message) {
+        if (this.resourceOwnerEventsLogger != null) {
+            this.resourceOwnerEventsLogger.publishLogEvent(String.format("%s\n", message));
+        }
+        if (this.platformLambdaLogger != null) {
+            this.platformLambdaLogger.log(String.format("%s\n", message));
         }
     }
 }

--- a/src/main/java/com/amazonaws/cloudformation/proxy/LoggerProxy.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/LoggerProxy.java
@@ -1,5 +1,6 @@
 package com.amazonaws.cloudformation.proxy;
 
+import com.amazonaws.cloudformation.logs.LogPublisher;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 
 /**
@@ -7,14 +8,18 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
  */
 public final class LoggerProxy implements Logger {
 
-    private final LambdaLogger lambdaLogger;
+    private final LambdaLogger platformLambdaLogger;
+    private final LogPublisher resourceOwnerEventsLogger;
 
-    public LoggerProxy(final LambdaLogger lambdaLogger) {
-        this.lambdaLogger = lambdaLogger;
+    public LoggerProxy(final LambdaLogger lambdaLogger, final LogPublisher resourceOwnerEventsLogger) {
+        this.platformLambdaLogger = lambdaLogger;
+        this.resourceOwnerEventsLogger = resourceOwnerEventsLogger;
     }
 
     @Override
     public void log(final String message) {
-        lambdaLogger.log(message);
+        platformLambdaLogger.log(message);
+        //NOTE: Exceptions might be thrown are handled inside LogPublisher.
+        resourceOwnerEventsLogger.publishLogEvent(message);
     }
 }

--- a/src/main/java/com/amazonaws/cloudformation/proxy/RequestData.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/RequestData.java
@@ -10,6 +10,8 @@ import java.util.Map;
 public class RequestData<ResourceT> {
     private Credentials callerCredentials;
     private Credentials platformCredentials;
+    private Credentials resourceOwnerLoggingCredentials;
+    private String resourceOwnerLoggingLogGroupName;
     private String logicalResourceId;
     private ResourceT resourceProperties;
     private ResourceT previousResourceProperties;

--- a/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
+++ b/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
@@ -1,6 +1,7 @@
 package com.amazonaws.cloudformation;
 
 import com.amazonaws.cloudformation.injection.CredentialsProvider;
+import com.amazonaws.cloudformation.logs.LogPublisher;
 import com.amazonaws.cloudformation.metrics.MetricsPublisher;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
 import com.amazonaws.cloudformation.proxy.CallbackAdapter;
@@ -37,13 +38,17 @@ public class WrapperOverride extends LambdaWrapper<TestModel, TestContext> {
      * This .ctor provided for testing
      */
     public WrapperOverride(final CallbackAdapter<TestModel> callbackAdapter,
-                           final CredentialsProvider credentialsProvider,
+                           final CredentialsProvider platformCredentialsProvider,
+                           final CredentialsProvider resourceOwnerLoggingCredentialsProvider,
+                           final LogPublisher resourceOwnerEventsLogger,
                            final MetricsPublisher metricsPublisher,
                            final CloudWatchScheduler scheduler,
                            final SchemaValidator validator) {
         super(
             callbackAdapter,
-            credentialsProvider,
+            platformCredentialsProvider,
+            resourceOwnerLoggingCredentialsProvider,
+            resourceOwnerEventsLogger,
             metricsPublisher,
             scheduler,
             validator,

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request-without-platform-credentials.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request-without-platform-credentials.json
@@ -13,6 +13,12 @@
             "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
             "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-model-fields.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-model-fields.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-request-fields.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.with-extraneous-request-fields.json
@@ -20,6 +20,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request.with-new-credentials.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request.with-new-credentials.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "UeJEwC/dqcYEn2viFd5TjKjR5TaMOfdeHrlLXxQL",
             "sessionToken": "469gs8raWJCaZcItXhGJ7dt3urI13fOTcde6ibhuHJz6r6bRRCWvLYGvCsqrN8WUClYL9lxZHymrWXvZ9xN0GoI2LFdcAAinZk5t"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/create.with-request-context.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.with-request-context.request.json
@@ -25,6 +25,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {},
         "systemTags": {

--- a/src/test/java/com/amazonaws/cloudformation/data/delete.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/delete.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/delete.with-request-context.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/delete.with-request-context.request.json
@@ -25,6 +25,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {}
     },

--- a/src/test/java/com/amazonaws/cloudformation/data/list.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/list.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/malformed.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/malformed.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "physicalResourceId": "",
         "resourceProperties": {},

--- a/src/test/java/com/amazonaws/cloudformation/data/no-response-endpoint.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/no-response-endpoint.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/read.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/read.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/update.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/update.request.json
@@ -18,6 +18,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {
             "property1": "abc",

--- a/src/test/java/com/amazonaws/cloudformation/data/update.with-request-context.request.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/update.with-request-context.request.json
@@ -25,6 +25,12 @@
             "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
             "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
         },
+        "resourceOwnerLoggingCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "resourceOwnerLoggingLogGroupName": "resourceOwnerLoggingGroupName",
         "logicalResourceId": "myBucket",
         "resourceProperties": {},
         "previousResourceProperties": {},

--- a/src/test/java/com/amazonaws/cloudformation/logs/LogPublisherImplTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/logs/LogPublisherImplTest.java
@@ -1,0 +1,174 @@
+package com.amazonaws.cloudformation.logs;
+
+import com.amazonaws.cloudformation.injection.CloudWatchEventsLogProvider;
+import com.amazonaws.cloudformation.injection.CloudWatchProvider;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogGroupRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.CreateLogStreamRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogGroupsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
+import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LogPublisherImplTest {
+
+    @Mock
+    private CloudWatchEventsLogProvider cloudWatchEventsLogProvider;
+
+    @Mock
+    private CloudWatchLogsClient cloudWatchLogsClient;
+
+
+    @Mock
+    private LambdaLogger platformLambdaLogger;
+
+    @Mock
+    private CloudWatchProvider platformCloudWatchProvider;
+
+    @Mock
+    private CloudWatchProvider resourceOwnerCloudWatchProvider;
+
+    @Mock
+    private CloudWatchClient platformCloudWatchClient;
+
+    @Mock
+    private CloudWatchClient resourceOwnerCloudWatchClient;
+
+    @Mock
+    private LogPublisher resourceOwnerEventsLogger;
+
+    private static final String LOG_GROUP_NAME = "log-group-name";
+
+    @BeforeEach
+    public void beforeEach() {
+//        when(platformCloudWatchProvider.get()).thenReturn(platformCloudWatchClient);
+//        when(platformCloudWatchClient.putMetricData(any(PutMetricDataRequest.class)))
+//                .thenReturn(mock(PutMetricDataResponse.class));
+        when(cloudWatchEventsLogProvider.get()).thenReturn(cloudWatchLogsClient);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        verifyNoMoreInteractions(platformCloudWatchProvider);
+        verifyNoMoreInteractions(platformCloudWatchClient);
+    }
+
+    @Test
+    public void testPublishLogEventsWithExistingLogGroup() {
+        final LogPublisherImpl logPublisher = new LogPublisherImpl(cloudWatchEventsLogProvider, LOG_GROUP_NAME, platformLambdaLogger);
+        final ArgumentCaptor<DescribeLogGroupsRequest> describeLogGroupsRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DescribeLogGroupsRequest.class);
+        final ArgumentCaptor<CreateLogStreamRequest> createLogStreamRequestArgumentCaptor =
+                ArgumentCaptor.forClass(CreateLogStreamRequest.class);
+        final ArgumentCaptor<PutLogEventsRequest> putLogEventsRequestArgumentCaptor =
+                ArgumentCaptor.forClass(PutLogEventsRequest.class);
+
+        final DescribeLogGroupsResponse describeLogGroupsResponse = DescribeLogGroupsResponse.builder().logGroups(
+                LogGroup.builder()
+                        .logGroupName(LOG_GROUP_NAME)
+                        .arn("arn:aws:logs:us-east-1:987721315229:log-group:/aws/lambda/testLogGroup-X:*")
+                        .creationTime(4567898765l)
+                        .storedBytes(456789l).build()
+        ).build();
+
+        when(cloudWatchLogsClient.describeLogGroups(describeLogGroupsRequestArgumentCaptor.capture()))
+                .thenReturn(describeLogGroupsResponse);
+        when(cloudWatchLogsClient.createLogStream(createLogStreamRequestArgumentCaptor.capture()))
+                .thenReturn(null);
+        when(cloudWatchLogsClient.putLogEvents(putLogEventsRequestArgumentCaptor.capture()))
+                .thenReturn(null);
+        final String msgToLog = "How is it going?";
+        logPublisher.initializeLoggingConditions();
+        logPublisher.publishLogEvent(msgToLog);
+
+        assertThat(describeLogGroupsRequestArgumentCaptor.getValue().logGroupNamePrefix()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(createLogStreamRequestArgumentCaptor.getValue().logGroupName()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logGroupName()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logStreamName())
+                .isEqualTo(createLogStreamRequestArgumentCaptor.getValue().logStreamName());
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logEvents().get(0).message())
+                .isEqualTo(msgToLog);
+
+        verify(cloudWatchLogsClient).describeLogGroups(describeLogGroupsRequestArgumentCaptor.getValue());
+        verify(cloudWatchLogsClient).createLogStream(createLogStreamRequestArgumentCaptor.getValue());
+        verify(cloudWatchLogsClient).putLogEvents(putLogEventsRequestArgumentCaptor.getValue());
+        verifyNoMoreInteractions(cloudWatchEventsLogProvider);
+    }
+
+    @Test
+    public void testPublishLogEventsCreatingNewLogGroup() {
+        final LogPublisherImpl logPublisher = new LogPublisherImpl(cloudWatchEventsLogProvider, LOG_GROUP_NAME, platformLambdaLogger);
+        final ArgumentCaptor<DescribeLogGroupsRequest> describeLogGroupsRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DescribeLogGroupsRequest.class);
+        final ArgumentCaptor<CreateLogStreamRequest> createLogStreamRequestArgumentCaptor =
+                ArgumentCaptor.forClass(CreateLogStreamRequest.class);
+        final ArgumentCaptor<CreateLogGroupRequest> createLogGroupRequestArgumentCaptor =
+                ArgumentCaptor.forClass(CreateLogGroupRequest.class);
+        final ArgumentCaptor<PutLogEventsRequest> putLogEventsRequestArgumentCaptor =
+                ArgumentCaptor.forClass(PutLogEventsRequest.class);
+
+        final DescribeLogGroupsResponse describeLogGroupsResponse = DescribeLogGroupsResponse.builder().logGroups(ImmutableList.of()).build();
+
+        when(cloudWatchLogsClient.describeLogGroups(describeLogGroupsRequestArgumentCaptor.capture()))
+                .thenReturn(describeLogGroupsResponse);
+        when(cloudWatchLogsClient.createLogGroup(createLogGroupRequestArgumentCaptor.capture()))
+                .thenReturn(null);
+        when(cloudWatchLogsClient.createLogStream(createLogStreamRequestArgumentCaptor.capture()))
+                .thenReturn(null);
+        when(cloudWatchLogsClient.putLogEvents(putLogEventsRequestArgumentCaptor.capture()))
+                .thenReturn(null);
+        final String msgToLog = "How is it going?";
+        logPublisher.initializeLoggingConditions();
+        logPublisher.publishLogEvent(msgToLog);
+
+        assertThat(describeLogGroupsRequestArgumentCaptor.getValue().logGroupNamePrefix()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(createLogGroupRequestArgumentCaptor.getValue().logGroupName()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(createLogStreamRequestArgumentCaptor.getValue().logGroupName()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logGroupName()).isEqualTo(LOG_GROUP_NAME);
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logStreamName())
+                .isEqualTo(createLogStreamRequestArgumentCaptor.getValue().logStreamName());
+        assertThat(putLogEventsRequestArgumentCaptor.getValue().logEvents().get(0).message())
+                .isEqualTo(msgToLog);
+
+        verify(cloudWatchLogsClient).describeLogGroups(describeLogGroupsRequestArgumentCaptor.getValue());
+        verify(cloudWatchLogsClient).createLogGroup(createLogGroupRequestArgumentCaptor.getValue());
+        verify(cloudWatchLogsClient).createLogStream(createLogStreamRequestArgumentCaptor.getValue());
+        verify(cloudWatchLogsClient).putLogEvents(putLogEventsRequestArgumentCaptor.getValue());
+        verifyNoMoreInteractions(cloudWatchEventsLogProvider);
+    }
+
+    @Test
+    public void testPublishLogEventsSkippedOutOfInitializationFailure() {
+        final LogPublisherImpl logPublisher = new LogPublisherImpl(cloudWatchEventsLogProvider, LOG_GROUP_NAME, platformLambdaLogger);
+        final ArgumentCaptor<DescribeLogGroupsRequest> describeLogGroupsRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DescribeLogGroupsRequest.class);
+
+        when(cloudWatchLogsClient.describeLogGroups(describeLogGroupsRequestArgumentCaptor.capture()))
+                .thenThrow(new RuntimeException("Sorry"));
+
+        final String msgToLog = "How is it going?";
+        logPublisher.initializeLoggingConditions();
+        logPublisher.publishLogEvent(msgToLog);
+
+        assertThat(describeLogGroupsRequestArgumentCaptor.getValue().logGroupNamePrefix()).isEqualTo(LOG_GROUP_NAME);
+
+        verify(cloudWatchLogsClient).describeLogGroups(describeLogGroupsRequestArgumentCaptor.getValue());
+        verifyNoMoreInteractions(cloudWatchEventsLogProvider);
+    }
+}

--- a/src/test/java/com/amazonaws/cloudformation/scheduler/CloudWatchSchedulerTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/scheduler/CloudWatchSchedulerTest.java
@@ -1,11 +1,11 @@
 package com.amazonaws.cloudformation.scheduler;
 
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.cloudformation.TestContext;
 import com.amazonaws.cloudformation.TestModel;
 import com.amazonaws.cloudformation.injection.CloudWatchEventsProvider;
 import com.amazonaws.cloudformation.proxy.HandlerRequest;
 import com.amazonaws.cloudformation.proxy.RequestContext;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 public class CloudWatchSchedulerTest {
 
     @Mock
-    private LambdaLogger logger;
+    private LambdaLogger platformLambdaLogger;
 
     @Mock
     private RequestContext<TestContext> requestContext;
@@ -52,7 +52,7 @@ public class CloudWatchSchedulerTest {
         final CloudWatchEventsClient client = getCloudWatchEvents();
         when(provider.get()).thenReturn(client);
         final CronHelper cronHelper = getCronHelper();
-        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, logger, cronHelper);
+        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, platformLambdaLogger, null, cronHelper);
         scheduler.refreshClient();
 
         scheduler.cleanupCloudWatchEvents(null, "targetid");
@@ -68,7 +68,7 @@ public class CloudWatchSchedulerTest {
         final CloudWatchEventsClient client = getCloudWatchEvents();
         when(provider.get()).thenReturn(client);
         final CronHelper cronHelper = getCronHelper();
-        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, logger, cronHelper);
+        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, platformLambdaLogger, null, cronHelper);
         scheduler.refreshClient();
 
         scheduler.cleanupCloudWatchEvents("rulename", null);
@@ -84,7 +84,7 @@ public class CloudWatchSchedulerTest {
         final CloudWatchEventsClient client = getCloudWatchEvents();
         when(provider.get()).thenReturn(client);
         final CronHelper cronHelper = getCronHelper();
-        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, logger, cronHelper);
+        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, platformLambdaLogger, null, cronHelper);
         scheduler.refreshClient();
 
         scheduler.cleanupCloudWatchEvents("rulename", "targetid");
@@ -102,7 +102,7 @@ public class CloudWatchSchedulerTest {
         final CronHelper cronHelper = getCronHelper();
         when(cronHelper.generateOneTimeCronExpression(1))
             .thenReturn("cron(41 14 31 10 ? 2019)");
-        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, logger, cronHelper);
+        final CloudWatchScheduler scheduler = new CloudWatchScheduler(provider, platformLambdaLogger, null, cronHelper);
         scheduler.refreshClient();
         final HandlerRequest<TestModel, TestContext> request = new HandlerRequest<>();
 


### PR DESCRIPTION
*Issue #107  Log and metrics delivery to resource owner
*Description of changes:
This change is based on the context that workflows runtime will be passing lambda wrapper logging credentials and log group name for delivering log & metrics to resource owner.

Changes for metrics is integrated with the existing implementation of MetricsPublisherImpl and changes for delivering logs is in new java file "LogPublisherImpl".

There are also a bunch of name refactoring for loggers to differentiate between logger for platform and resource owner. 