### PR TITLE
Log stack trace for uncaught throwable

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
+++ b/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
@@ -289,6 +289,18 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         return handlerResponse;
     }
 
+    private void logUnhandledError(
+            final String errorDescription,
+            final HandlerRequest<ResourceT, CallbackT> request,
+            final Throwable e) {
+        this.logger.log(String.format("%s in a %s action on a %s: %s%n%s",
+                errorDescription,
+                request.getAction(),
+                request.getResourceType(),
+                e.toString(),
+                ExceptionUtils.getStackTrace(e)));
+    }
+
     /**
      * Invokes the handler implementation for the request, and wraps with try-catch to consistently
      * handle certain classes of errors and correctly map those to the appropriate HandlerErrorCode
@@ -318,29 +330,25 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
 
         } catch (final ResourceAlreadyExistsException e) {
             this.metricsPublisher.publishExceptionMetric(Instant.now(), request.getAction(), e);
-            this.logger.log(String.format("An existing resource was found in a %s action on a $s: %s" +
-                request.getAction(), request.getResourceType(), e.toString()));
+            logUnhandledError("An existing resource was found", request, e);
             return ProgressEvent.defaultFailureHandler(
                 e,
                 HandlerErrorCode.AlreadyExists);
         } catch (final ResourceNotFoundException e) {
             this.metricsPublisher.publishExceptionMetric(Instant.now(), request.getAction(), e);
-            this.logger.log(String.format("A requested resource was not found in a %s action on a $s: %s" +
-                request.getAction(), request.getResourceType(), e.toString()));
+            logUnhandledError("A requested resource was not found", request, e);
             return ProgressEvent.defaultFailureHandler(
                 e,
                 HandlerErrorCode.NotFound);
         } catch (final AmazonServiceException e) {
             this.metricsPublisher.publishExceptionMetric(Instant.now(), request.getAction(), e);
-            this.logger.log(String.format("A downstream service error occurred in a %s action on a %s: %s",
-                request.getAction(), request.getResourceType(), e.toString()));
+            logUnhandledError("A downstream service error occurred", request, e);
             return ProgressEvent.defaultFailureHandler(
                 e,
                 HandlerErrorCode.ServiceException);
         } catch (final Throwable e) {
             this.metricsPublisher.publishExceptionMetric(Instant.now(), request.getAction(), e);
-            this.logger.log(String.format("An unknown error occurred in a %s action on a %s: %s\n%s",
-                request.getAction(), request.getResourceType(), e.toString(), ExceptionUtils.getStackTrace(e)));
+            logUnhandledError("An unknown error occurred ", request, e);
             return ProgressEvent.defaultFailureHandler(
                 e,
                 HandlerErrorCode.InternalFailure);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Log stack trace for uncaught throwable. I don't think it's needed in all cases, but some of them were using `$s`, so making the log method uniform made sense to me.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
