### PR TITLE
Limit information in ResourceHandlerRequest

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -81,15 +81,10 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
         }
 
         return new ResourceHandlerRequest<{{ pojo_name }}>(
-            request.getAwsAccountId(),
             request.getBearerToken(),
-            request.getRequestData().getLogicalResourceId(),
-            request.getNextToken(),
-            request.getRegion(),
-            request.getResourceType(),
-            request.getResourceTypeVersion(),
             desiredResourceState,
-            previousResourceState
+            previousResourceState,
+            request.getRequestData().getLogicalResourceId()
         );
     }
 

--- a/src/main/java/com/amazonaws/cloudformation/proxy/ResourceHandlerRequest.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/ResourceHandlerRequest.java
@@ -15,13 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder(toBuilder = true)
 public class ResourceHandlerRequest<T> {
-    private String awsAccountId;
     private String clientRequestToken;
-    private String logicalResourceIdentifier;
-    private String nextToken;
-    private String region;
-    private String resourceType;
-    private String resourceTypeVersion;
     private T desiredResourceState;
     private T previousResourceState;
+    private String logicalResourceIdentifier;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Limit the information contained in `ResourceHandlerRequest`. We can always add this information back in slowly as use-cases require it. This PR may be excessive, and I'm expecting some discussion.

My understanding for why it's there:

* clientRequestToken - idempotency, obviously required
* desiredResourceState - required for create, update
* previousResourceState - required for update
* logicalResourceIdentifier - hack/cloudformation abstraction leakage, required for now
* awsAccountId - no idea, this shouldn't be exposed
* nextToken - see #96 , maybe re-introduce with a more obvious name like `listNextToken` or `listPaginationToken`? the guidance on list handlers is already minimal, i'm struggling to understand in which context they'll be able to list things (accounts?), and how a next token would be returned by the list operation. see also #63 for other issues.
* region - i can see why this may seem useful for debug, but really since the handlers are regional there should be minimal confusion where the logs are going
* resourceType - maybe for multiple types in one project?
* resourceTypeVersion - don't know. this seems like a bad idea, and will be exceedingly hard for the contract tests to provide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
