### PR TITLE
Remove ProgressEvent helper methods being serialized

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/proxy/AmazonWebServicesClientProxy.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/AmazonWebServicesClientProxy.java
@@ -220,7 +220,8 @@ public class AmazonWebServicesClientProxy implements CallChain {
                                     } catch (Exception e) {
                                         ProgressEvent<ModelT,
                                             CallbackT> handled = exceptHandler.invoke(req, e, client, model, context);
-                                        if (handled.isFailed() || handled.isSuccess()) {
+                                        if (handled.getStatus() == OperationStatus.FAILED
+                                            || handled.getStatus() == OperationStatus.SUCCESS) {
                                             return handled;
                                         }
                                     }

--- a/src/main/java/com/amazonaws/cloudformation/proxy/ProgressEvent.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/ProgressEvent.java
@@ -129,21 +129,4 @@ public class ProgressEvent<ResourceT, CallbackT> {
         onSuccess(Function<ProgressEvent<ResourceT, CallbackT>, ProgressEvent<ResourceT, CallbackT>> func) {
         return (status != null && status == OperationStatus.SUCCESS) ? func.apply(this) : this;
     }
-
-    public boolean isFailed() {
-        return status == OperationStatus.FAILED;
-    }
-
-    public boolean isInProgress() {
-        return status == OperationStatus.IN_PROGRESS;
-    }
-
-    public boolean isSuccess() {
-        return status == OperationStatus.SUCCESS;
-    }
-
-    public boolean isInProgressCallbackDelay() {
-        return isInProgress() && callbackDelaySeconds > 0;
-    }
-
 }

--- a/src/test/java/com/amazonaws/cloudformation/proxy/ProgressEventTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/proxy/ProgressEventTest.java
@@ -18,7 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.cloudformation.TestContext;
 import com.amazonaws.cloudformation.TestModel;
+import com.amazonaws.cloudformation.resource.Serializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 public class ProgressEventTest {
@@ -65,5 +68,16 @@ public class ProgressEventTest {
         assertThat(progressEvent.getResourceModel()).isEqualTo(model);
         assertThat(progressEvent.getResourceModels()).isNull();
         assertThat(progressEvent.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    }
+
+    @Test
+    public void progressEvent_serialize_shouldReturnJson() throws JsonProcessingException {
+        final ProgressEvent<String, String> progressEvent = ProgressEvent.defaultSuccessHandler("");
+        final Serializer serializer = new Serializer();
+        final JSONObject json = serializer.serialize(progressEvent);
+
+        // careful if you add new properties here. downstream has to be able to handle
+        // them
+        assertThat(json).hasToString("{\"callbackDelaySeconds\":0,\"resourceModel\":\"\",\"status\":\"SUCCESS\"}");
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A, introduced by #112

*Description of changes:* The helper methods added to `ProgressEvent` are being serialized:

```json
{
  "status": "FAILED",
  "errorCode": "InternalFailure",
  "message": "<snip>",
  "callbackDelaySeconds": 0,
  "inProgress": false,
  "failed": true,
  "success": false,
  "inProgressCallbackDelay": false
}
```

`inProgress`, `failed`, `success`, and `inProgressCallbackDelay` are automatically being serialized. I'm sure there's an annotation to stop this, but they're barely being used, so this is quicker since this is blocking the contract tests.

Added unit test to catch this in future:

```
Expecting actual's toString() to return:
  <"{"callbackDelaySeconds":0,"resourceModel":"","status":"SUCCESS"}">
but was:
  <{"callbackDelaySeconds":0,"inProgress":false,"success":true,"resourceModel":"","inProgressCallbackDelay":false,"failed":false,"status":"SUCCESS"}>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
