### PR TITLE
Prevent ProgressEvent helper methods being serialized

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/proxy/ProgressEvent.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/ProgressEvent.java
@@ -14,10 +14,11 @@
 */
 package com.amazonaws.cloudformation.proxy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/test/java/com/amazonaws/cloudformation/proxy/ProgressEventTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/proxy/ProgressEventTest.java
@@ -18,9 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.cloudformation.TestContext;
 import com.amazonaws.cloudformation.TestModel;
-
 import com.amazonaws.cloudformation.resource.Serializer;
 import com.fasterxml.jackson.core.JsonProcessingException;
+
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
*Issue #, if available:* N/A, introduced by #112, see also a worse attempt in #120 

*Description of changes:* The helper methods added to `ProgressEvent` are being serialized:

```json
{
  "status": "FAILED",
  "errorCode": "InternalFailure",
  "message": "<snip>",
  "callbackDelaySeconds": 0,
  "inProgress": false,
  "failed": true,
  "success": false,
  "inProgressCallbackDelay": false
}
```

`inProgress`, `failed`, `success`, and `inProgressCallbackDelay` are automatically being serialized. I'm sure there's an annotation to stop this, but they're barely being used, so this is quicker since this is blocking the contract tests.

Added unit test to catch this in future:

```
Expecting actual's toString() to return:
  <"{"callbackDelaySeconds":0,"resourceModel":"","status":"SUCCESS"}">
but was:
  <{"callbackDelaySeconds":0,"inProgress":false,"success":true,"resourceModel":"","inProgressCallbackDelay":false,"failed":false,"status":"SUCCESS"}>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
