### PR TITLE
Shared handler for common functionality

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -40,7 +40,7 @@ class JavaLanguagePlugin(LanguagePlugin):
         )
         self.package_name = ".".join(self.namespace)
 
-    def init(self, project):
+    def init(self, project):  # pylint: disable=too-many-statements
         LOG.debug("Init started")
 
         self._namespace_from_project(project)
@@ -111,6 +111,12 @@ class JavaLanguagePlugin(LanguagePlugin):
         LOG.debug("Writing callback context")
         template = self.env.get_template("CallbackContext.java")
         path = src / "CallbackContext.java"
+        contents = template.render(package_name=self.package_name)
+        project.safewrite(path, contents)
+
+        LOG.debug("Writing shared handler")
+        template = self.env.get_template("SharedHandler.java")
+        path = src / "SharedHandler.java"
         contents = template.render(package_name=self.package_name)
         project.safewrite(path, contents)
 

--- a/python/rpdk/java/templates/SharedHandler.java
+++ b/python/rpdk/java/templates/SharedHandler.java
@@ -1,0 +1,5 @@
+package {{ package_name }};
+
+public abstract class SharedHandler extends BaseHandler<CallbackContext> {
+
+}

--- a/python/rpdk/java/templates/StubHandler.java
+++ b/python/rpdk/java/templates/StubHandler.java
@@ -6,7 +6,7 @@ import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 
-public class {{ operation }}Handler extends BaseHandler<CallbackContext> {
+public class {{ operation }}Handler extends SharedHandler {
 
     @Override
     public ProgressEvent<{{ pojo_name }}, CallbackContext> handleRequest(

--- a/python/rpdk/java/templates/StubListHandler.java
+++ b/python/rpdk/java/templates/StubListHandler.java
@@ -9,7 +9,7 @@ import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 import java.util.ArrayList;
 import java.util.List;
 
-public class {{ operation }}Handler extends BaseHandler<CallbackContext> {
+public class {{ operation }}Handler extends SharedHandler {
 
     @Override
     public ProgressEvent<{{ pojo_name }}, CallbackContext> handleRequest(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Insert shared handler between BaseHandler and operation handlers. This can be used for common functionality or helper methods.

This is purely an enhancement, and an idea I'm putting out there. Right now, the handlers have this form:

```java
public class CreateHandler extends BaseHandler<CallbackContext> {
...
}
```

`BaseHandler` is auto-generated, so can't be edited. Of course, it's trivial to manually insert another class in there, which I did when implementing a toy resource, so I thought it could be useful.

`SharedHandler` (still not hot about the name to be honest) is simply:

```java
public abstract class SharedHandler extends BaseHandler<CallbackContext> {

}
```

While the handlers become:

```java
public class CreateHandler extends SharedHandler {
...
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
