### PR TITLE
Initialize loggerProxy

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -71,6 +71,8 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             final OutputStream outputStream,
             final Context context) throws IOException {
 
+        this.loggerProxy = new LoggerProxy();
+
         ProgressEvent<{{ pojo_name }}, CallbackContext> response = ProgressEvent.failed(null, null, HandlerErrorCode.InternalFailure, "Uninitialized");
         try {
             final String input = IOUtils.toString(inputStream, "UTF-8");


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* `loggerProxy` was not being initialized for test entrypoint. Tested with MetricFilter example:

```
$ cat
{
    "credentials": {
        ...
    },
    "action": "CREATE",
    "request": {
        "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
        "desiredResourceState": {
            "FilterPattern": "[ip, identity, user_id, timestamp, request, status_code = 404, size]",
            "FilterName": "MyFilter",
            "LogGroupName": "MyLogGroup",
            "MetricTransformations": [
                {
                    "MetricName": "MyMetric",
                    "MetricNamespace": "MyNamespace",
                    "MetricValue": "1"
                }
            ]
        },
        "logicalResourceIdentifier": "MyResource"
    },
    "callbackContext": null
}
$ sam local invoke TestEntrypoint --event create.json
2019-08-09 15:48:20 Invoking com.amazonaws.logs.metricfilter.HandlerWrapper::testEntrypoint (java8)
2019-08-09 15:48:20 Found credentials in environment variables.
2019-08-09 15:48:20 Decompressing /workplace/tobflem/aws-cloudformation-rpdk/tmp/target/aws-logs-metricfilter-handler-1.0-SNAPSHOT.jar                                                                                                           

Fetching lambci/lambda:java8 Docker container image......
2019-08-09 15:48:29 Mounting /private/var/folders/mx/9slqrbw53x19906_4zj3r2f8ln76fz/T/tmpffeysov3 as /var/task:ro,delegated inside runtime container                                                                                             
START RequestId: 1031ec8b-1258-454c-bc64-525768177956 Version: $LATEST
END RequestId: 1031ec8b-1258-454c-bc64-525768177956
REPORT RequestId: 1031ec8b-1258-454c-bc64-525768177956  Duration: 4316.16 ms    Billed Duration: 4400 ms        Memory Size: 128 MB     Max Memory Used: 10 MB                                                                                   

{"callbackDelaySeconds":0,"resourceModel":{"MetricTransformations":[{"MetricName":"MyMetric","MetricValue":"1","MetricNamespace":"MyNamespace"}],"FilterPattern":"[ip, identity, user_id, timestamp, request, status_code = 404, size]","LogGroupName":"MyLogGroup","FilterName":"2a8f83f7-f2a0-4af4-9339-86518e3348eb"},"status":"SUCCESS"}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
