### PR TITLE
Capitalizing primaryIdentifier component causing failures with lowerc…

### DIFF
--- a/python/rpdk/java/templates/POJO.java
+++ b/python/rpdk/java/templates/POJO.java
@@ -48,7 +48,7 @@ public class {{ pojo_name|uppercase_first_letter }} {
         final JSONObject identifier = new JSONObject();
         {% for identifier in primaryIdentifier %}
         {% set components = identifier.split("/") %}
-        if (this.get{{components[2]}}() != null
+        if (this.get{{components[2]|uppercase_first_letter}}() != null
             {%- for i in range(4, components|length + 1) -%}
                 {#- #} && this
                 {%- for component in components[2:i] -%} .get{{component|uppercase_first_letter}}() {%- endfor -%}


### PR DESCRIPTION
…ased identifiers

*Issue #, if available:* #146 

*Description of changes:* We missed an uppercase in the codegen that causes failures when primary identifiers are not capitalized. This makes a small change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
