### PR TITLE
Default handlers to all operations

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -226,7 +226,9 @@ class JavaLanguagePlugin(LanguagePlugin):
         template = self.env.get_template("HandlerWrapper.java")
         contents = template.render(
             package_name=self.package_name,
-            operations=project.schema.get("handlers", dict.fromkeys(OPERATIONS, {})).keys(),
+            operations=project.schema.get(
+                "handlers", dict.fromkeys(OPERATIONS, {})
+            ).keys(),
             pojo_name="ResourceModel",
         )
         project.overwrite(path, contents)


### PR DESCRIPTION
*Issue #, if available:*

## Description
PR(aws-cloudformation/aws-cloudformation-rpdk-java-plugin#152) uses empty operation if no `handlers` defined in the schema. Therefore, no action will be available in the generated HandlerWrapper.   

Because `handlers` is not required in the schema, if a schema doesn't define `handlers`, this issue will only be found during runtime.

I have a fix on the SES(https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ses/pull/22).  But this fix will default handlers to all operations if no handlers defined in the schema. It keeps the backward compatibility with current schema.

## Testing
Verified in the SES::ConfigurationSet without handlers. The HandlerWrapper is generated with all handlers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
