### PR TITLE
Make JSON properties safe for reserved keywords

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -33,6 +33,7 @@ class JavaLanguagePlugin(LanguagePlugin):
             trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True
         )
         self.env.filters["translate_type"] = translate_type
+        self.env.filters["safe_reserved"] = safe_reserved
         self.namespace = None
         self.package_name = None
 

--- a/python/rpdk/java/templates/POJO.java
+++ b/python/rpdk/java/templates/POJO.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class {{ model_name|uppercase_first_letter }} {
     {% for name, type in properties.items() %}
     @JsonProperty("{{ name }}")
-    private {{ type|translate_type }} {{ name|lowercase_first_letter }};
+    private {{ type|translate_type }} {{ name|lowercase_first_letter|safe_reserved }};
 
     {% endfor %}
 }

--- a/python/rpdk/java/templates/ResourceModel.java
+++ b/python/rpdk/java/templates/ResourceModel.java
@@ -37,7 +37,7 @@ public class {{ model_name|uppercase_first_letter }} {
 
     {% for name, type in properties.items() %}
     @JsonProperty("{{ name }}")
-    private {{ type|translate_type }} {{ name|lowercase_first_letter }};
+    private {{ type|translate_type }} {{ name|lowercase_first_letter|safe_reserved }};
 
     {% endfor %}
     @JsonIgnore


### PR DESCRIPTION
Issue #288 in aws-cloudformation-rpdk
[(https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/288)]

These changes allow java keywords to be safely included as properties inside of customer schemas. Following from the example in the issue referenced above:

The schema:
```
{
  "type": "My::GitHub::Repo",
  "primaryIdentifier": "/properties/id",
  "properties": {
    "id": {
       "type": "string"
    },
    "private": {
      "type": "boolean"
    }
  }
}
```

Should now yield the following ResourceModel:
```
public class ResourceModel {
    @JsonIgnore
    public static final String TYPE_NAME = "My::GitHub::Repo";
    @JsonIgnore
    public static final String IDENTIFIER_KEY_ID = "/properties/id";
    @JsonProperty("id")
    private Integer id;
    @JsonProperty("private")
    private Boolean private_;
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
