### PR TITLE
Handle exceptions that should be mapped to specific errorCodes

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -1,7 +1,10 @@
 // This is a generated file. Modifications will be overwritten.
 package {{ package_name }};
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.cloudformation.Action;
+import com.amazonaws.cloudformation.exceptions.ResourceAlreadyExistsException;
+import com.amazonaws.cloudformation.exceptions.ResourceNotFoundException;
 import com.amazonaws.cloudformation.LambdaWrapper;
 import com.amazonaws.cloudformation.metrics.MetricsPublisher;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -88,6 +91,12 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
                 loggerProxy, payload.getCredentials(), () -> (long) context.getRemainingTimeInMillis());
 
             response = invokeHandler(proxy, payload.getRequest(), payload.getAction(), payload.getCallbackContext());
+        } catch (final ResourceAlreadyExistsException e) {
+            response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.AlreadyExists);
+        } catch (final ResourceNotFoundException e) {
+            response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
+        } catch (final AmazonServiceException e) {
+            response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.GeneralServiceException);
         } catch (final Throwable e) {
             e.printStackTrace();
             response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InternalFailure);

--- a/src/main/java/com/amazonaws/cloudformation/proxy/CallbackAdapter.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/CallbackAdapter.java
@@ -14,8 +14,6 @@
 */
 package com.amazonaws.cloudformation.proxy;
 
-import java.io.IOException;
-
 /**
  * Interface used to abstract the function of reporting back provisioning
  * progress to the handler caller


### PR DESCRIPTION
*Issue #, if available:* #165 

*Description of changes:* This adds exception handling to return the correct errorCodes when exceptions are thrown from handler for contract tests. A more elegant refactor of both this and the regular entrypoint handling is probably necessary, but this unblocks the contract tests for now


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
