### PR TITLE
use put instead of append in identifier pojo

### DIFF
--- a/python/rpdk/java/templates/ResourceModel.java
+++ b/python/rpdk/java/templates/ResourceModel.java
@@ -52,7 +52,7 @@ public class {{ model_name|uppercase_first_letter }} {
                 {#- #} != null
             {%- endfor -%}
         ) {
-            identifier.append(IDENTIFIER_KEY_{{ components[2:]|join('_')|upper }}, this{% for component in components[2:] %}.get{{component|uppercase_first_letter}}(){% endfor %});
+            identifier.put(IDENTIFIER_KEY_{{ components[2:]|join('_')|upper }}, this{% for component in components[2:] %}.get{{component|uppercase_first_letter}}(){% endfor %});
         }
 
         {% endfor %}
@@ -85,7 +85,7 @@ public class {{ model_name|uppercase_first_letter }} {
                 {#- #} != null
             {%- endfor -%}
         ) {
-            identifier.append(IDENTIFIER_KEY_{{ components[2:]|join('_')|upper }}, this{% for component in components[2:] %}.get{{component|uppercase_first_letter}}(){% endfor %});
+            identifier.put(IDENTIFIER_KEY_{{ components[2:]|join('_')|upper }}, this{% for component in components[2:] %}.get{{component|uppercase_first_letter}}(){% endfor %});
         }
 
         {% endfor %}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Found when testing Dummy resource. append creates the object as a JSONArray, instead of as a String (or whatever type), as originally intended. Put is what we want

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
