### PR TITLE
Adds cfn-cli validate to build process

### DIFF
--- a/python/rpdk/java/templates/pom.xml
+++ b/python/rpdk/java/templates/pom.xml
@@ -105,6 +105,18 @@
                 <version>1.6.0</version>
                 <executions>
                     <execution>
+                        <id>validate</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>{{ executable }}</executable>
+                            <commandlineArgs>validate</commandlineArgs>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate</id>
                         <phase>generate-sources</phase>
                         <goals>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adding `cfn-cli validate` command to POM build step, prior to `cfn-cli generate` to reduce likelihood of invalid schemas and identify early on error.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
