### PR TITLE
Adding lambda logger for testEntrypoint

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -5,6 +5,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.cloudformation.Action;
 import com.amazonaws.cloudformation.exceptions.BaseHandlerException;
 import com.amazonaws.cloudformation.LambdaWrapper;
+import com.amazonaws.cloudformation.loggers.LambdaLogPublisher;
 import com.amazonaws.cloudformation.metrics.MetricsPublisher;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
 import com.amazonaws.cloudformation.proxy.CallbackAdapter;
@@ -77,6 +78,7 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             final Context context) throws IOException {
 
         this.loggerProxy = new LoggerProxy();
+        this.loggerProxy.addLogPublisher(new LambdaLogPublisher(context.getLogger()));
 
         ProgressEvent<{{ pojo_name }}, CallbackContext> response = ProgressEvent.failed(null, null, HandlerErrorCode.InternalFailure, "Uninitialized");
         try {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Previously we didn't have any log publishers set up when invoking the test entrypoint. With this addition, when performing contract tests logs will now be present in the `sam local start-lambda` output or in a log file if `--log-file` is specified on the command. Example logs:
```
^[[32mSTART RequestId: 2ba634ef-4652-4920-a86c-f19a015833b8 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
{"/properties/LogGroupName":["S"]} does not exist; creating the resource.AWS::Logs::LogGroup [S] successfully created.AWS::Logs::LogGroup [S] successfully applied retention in days: [7].^[[32mEND RequestId: 2ba634ef-4652-4920-a86c-f19a015833b8^[[0m
^[[32mREPORT RequestId: 2ba634ef-4652-4920-a86c-f19a015833b8    Duration: 8339.20 ms    Billed Duration: 8400 ms        Memory Size: 128 MB     Max Memory Used: 10 MB  ^[[0m
^[[32mSTART RequestId: 796670de-c103-406b-a6a3-63979934302d Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
AWS::Logs::LogGroup [S] successfully deleted.^[[32mEND RequestId: 796670de-c103-406b-a6a3-63979934302d^[[0m
^[[32mREPORT RequestId: 796670de-c103-406b-a6a3-63979934302d    Duration: 8086.36 ms    Billed Duration: 8100 ms        Memory Size: 128 MB     Max Memory Used: 7 MB   ^[[0m
^[[32mSTART RequestId: dd37b282-cc65-4129-8972-d52cdade91a6 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
{"/properties/LogGroupName":["/M0xWpQ/."]} does not exist; creating the resource.AWS::Logs::LogGroup [/M0xWpQ/.] successfully created.AWS::Logs::LogGroup [/M0xWpQ/.] successfully applied retention in days: [60].^[[32mEND RequestId: dd37b282-cc65-4129-8972-d52cdade91a6^[[0m
^[[32mREPORT RequestId: dd37b282-cc65-4129-8972-d52cdade91a6    Duration: 11071.75 ms   Billed Duration: 11100 ms       Memory Size: 128 MB     Max Memory Used: 7 MB   ^[[0m
^[[32mSTART RequestId: 9f1ebc82-2ac5-4128-a131-8f4eeeffbcdd Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
^[[32mEND RequestId: 9f1ebc82-2ac5-4128-a131-8f4eeeffbcdd^[[0m
^[[32mREPORT RequestId: 9f1ebc82-2ac5-4128-a131-8f4eeeffbcdd    Duration: 8024.25 ms    Billed Duration: 8100 ms        Memory Size: 128 MB     Max Memory Used: 9 MB   ^[[0m
^[[32mSTART RequestId: f4e5056c-c60a-4804-8454-0e8d32e9baa6 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
AWS::Logs::LogGroup [/M0xWpQ/.] successfully deleted.^[[32mEND RequestId: f4e5056c-c60a-4804-8454-0e8d32e9baa6^[[0m
^[[32mREPORT RequestId: f4e5056c-c60a-4804-8454-0e8d32e9baa6    Duration: 6485.30 ms    Billed Duration: 6500 ms        Memory Size: 128 MB     Max Memory Used: 7 MB   ^[[0m
^[[32mSTART RequestId: 3529f643-c1cb-42b2-b6ee-a9594a1caa27 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
{"/properties/LogGroupName":["0"]} does not exist; creating the resource.AWS::Logs::LogGroup [0] successfully created.AWS::Logs::LogGroup [0] successfully applied retention in days: [1].^[[32mEND RequestId: 3529f643-c1cb-42b2-b6ee-a9594a1caa27^[[0m
^[[32mREPORT RequestId: 3529f643-c1cb-42b2-b6ee-a9594a1caa27    Duration: 8045.54 ms    Billed Duration: 8100 ms        Memory Size: 128 MB     Max Memory Used: 7 MB   ^[[0m
^[[32mSTART RequestId: 37ef4c67-24ba-48d0-bf38-2b251f0db158 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
AWS::Logs::LogGroup [0] successfully deleted.^[[32mEND RequestId: 37ef4c67-24ba-48d0-bf38-2b251f0db158^[[0m
^[[32mREPORT RequestId: 37ef4c67-24ba-48d0-bf38-2b251f0db158    Duration: 6747.02 ms    Billed Duration: 6800 ms        Memory Size: 128 MB     Max Memory Used: 7 MB   ^[[0m
^[[32mSTART RequestId: 827f6911-7cb6-4943-b037-cad67b868416 Version: $LATEST^[[0m
Setting up loggingSLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Probably more needs to be done to format the logs correctly, but I wanted to get this in to quickly unblock anyone having issues with logs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
