### PR TITLE
Accepting empty/missing `callerCredentials`

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
+++ b/src/main/java/com/amazonaws/cloudformation/LambdaWrapper.java
@@ -386,12 +386,14 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         // within that period,
         // such as before a FAS token expires
 
-        // last mile proxy creation with passed-in credentials
-        AmazonWebServicesClientProxy awsClientProxy = new AmazonWebServicesClientProxy(requestContext == null, this.loggerProxy,
-                                                                                       request.getRequestData()
-                                                                                           .getCallerCredentials(),
-                                                                                       () -> (long) context
-                                                                                           .getRemainingTimeInMillis());
+        // last mile proxy creation with passed-in credentials (unless we are operating
+        // in a non-AWS model)
+        AmazonWebServicesClientProxy awsClientProxy = null;
+        if (request.getRequestData().getCallerCredentials() != null) {
+            awsClientProxy = new AmazonWebServicesClientProxy(requestContext == null, this.loggerProxy,
+                                                              request.getRequestData().getCallerCredentials(),
+                                                              () -> (long) context.getRemainingTimeInMillis());
+        }
 
         boolean computeLocally = true;
         ProgressEvent<ResourceT, CallbackT> handlerResponse = null;

--- a/src/test/java/com/amazonaws/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/com/amazonaws/cloudformation/LambdaWrapperTest.java
@@ -206,6 +206,12 @@ public class LambdaWrapperTest {
             // verify output response
             verifyHandlerResponse(out, HandlerResponse.<TestModel>builder().bearerToken("123456").errorCode("InternalFailure")
                 .operationStatus(OperationStatus.FAILED).message("Handler failed to provide a response.").build());
+
+            // assert handler receives correct injections
+            assertThat(wrapper.awsClientProxy).isNotNull();
+            assertThat(wrapper.getRequest()).isEqualTo(resourceHandlerRequest);
+            assertThat(wrapper.action).isEqualTo(action);
+            assertThat(wrapper.callbackContext).isNull();
         }
     }
 
@@ -313,6 +319,12 @@ public class LambdaWrapperTest {
             // verify output response
             verifyHandlerResponse(out, HandlerResponse.<TestModel>builder().bearerToken("123456").errorCode("InternalFailure")
                 .operationStatus(OperationStatus.FAILED).message("Custom Fault").build());
+
+            // assert handler receives correct injections
+            assertThat(wrapper.awsClientProxy).isNotNull();
+            assertThat(wrapper.getRequest()).isEqualTo(resourceHandlerRequest);
+            assertThat(wrapper.action).isEqualTo(action);
+            assertThat(wrapper.callbackContext).isNull();
         }
     }
 
@@ -386,6 +398,12 @@ public class LambdaWrapperTest {
             // verify output response
             verifyHandlerResponse(out,
                 HandlerResponse.<TestModel>builder().bearerToken("123456").operationStatus(OperationStatus.SUCCESS).build());
+
+            // assert handler receives correct injections
+            assertThat(wrapper.awsClientProxy).isNotNull();
+            assertThat(wrapper.getRequest()).isEqualTo(resourceHandlerRequest);
+            assertThat(wrapper.action).isEqualTo(action);
+            assertThat(wrapper.callbackContext).isNull();
         }
     }
 
@@ -455,6 +473,11 @@ public class LambdaWrapperTest {
             verifyNoMoreInteractions(providerMetricsPublisher);
             verifyNoMoreInteractions(scheduler);
 
+            // assert handler receives correct injections
+            assertThat(wrapper.awsClientProxy).isNotNull();
+            assertThat(wrapper.getRequest()).isEqualTo(resourceHandlerRequest);
+            assertThat(wrapper.action).isEqualTo(action);
+            assertThat(wrapper.callbackContext).isNull();
         }
     }
 
@@ -689,6 +712,41 @@ public class LambdaWrapperTest {
     }
 
     @Test
+    public void invokeHandler_withoutCallerCredentials_passesNoAWSProxy() throws IOException {
+        final WrapperOverride wrapper = new WrapperOverride(callbackAdapter, platformCredentialsProvider,
+                                                            providerLoggingCredentialsProvider, platformEventsLogger,
+                                                            providerEventsLogger, platformMetricsPublisher,
+                                                            providerMetricsPublisher, scheduler, validator);
+
+        final TestModel model = new TestModel();
+        model.setProperty1("abc");
+        model.setProperty2(123);
+        wrapper.setTransformResponse(resourceHandlerRequest);
+
+        // respond with immediate success to avoid callback invocation
+        final ProgressEvent<TestModel, TestContext> pe = ProgressEvent.<TestModel, TestContext>builder()
+            .status(OperationStatus.SUCCESS).resourceModel(model).build();
+        wrapper.setInvokeHandlerResponse(pe);
+
+        // without platform credentials the handler is unable to do
+        // basic SDK initialization and any such request should fail fast
+        try (final InputStream in = loadRequestStream("create.request-without-caller-credentials.json");
+            final OutputStream out = new ByteArrayOutputStream()) {
+            final Context context = getLambdaContext();
+
+            wrapper.handleRequest(in, out, context);
+
+            // verify output response
+            verifyHandlerResponse(out,
+                HandlerResponse.<TestModel>builder().bearerToken("123456").operationStatus(OperationStatus.SUCCESS)
+                    .resourceModel(TestModel.builder().property1("abc").property2(123).build()).build());
+
+            // proxy should be null by virtue of having not had callerCredentials passed in
+            assertThat(wrapper.awsClientProxy).isNull();
+        }
+    }
+
+    @Test
     public void invokeHandler_withDefaultInjection_returnsSuccess() throws IOException {
         final WrapperOverride wrapper = new WrapperOverride(callbackAdapter, platformCredentialsProvider,
                                                             providerLoggingCredentialsProvider, platformEventsLogger,
@@ -717,6 +775,9 @@ public class LambdaWrapperTest {
             verifyHandlerResponse(out,
                 HandlerResponse.<TestModel>builder().bearerToken("123456").operationStatus(OperationStatus.SUCCESS)
                     .resourceModel(TestModel.builder().property1("abc").property2(123).build()).build());
+
+            // proxy uses caller credentials and will be injected
+            assertThat(wrapper.awsClientProxy).isNotNull();
         }
     }
 

--- a/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
+++ b/src/test/java/com/amazonaws/cloudformation/WrapperOverride.java
@@ -81,6 +81,11 @@ public class WrapperOverride extends LambdaWrapper<TestModel, TestContext> {
                                                                final Action action,
                                                                final TestContext callbackContext)
         throws Exception {
+        this.awsClientProxy = awsClientProxy;
+        this.request = request;
+        this.action = action;
+        this.callbackContext = callbackContext;
+
         if (invokeHandlerException != null) {
             throw invokeHandlerException;
         } else if (invokeHandlerResponses == null) {
@@ -88,7 +93,14 @@ public class WrapperOverride extends LambdaWrapper<TestModel, TestContext> {
         } else {
             return invokeHandlerResponses.remove();
         }
+
     }
+
+    // lets tests assert on the passed in arguments
+    public AmazonWebServicesClientProxy awsClientProxy;
+    public ResourceHandlerRequest<TestModel> request;
+    public Action action;
+    public TestContext callbackContext;
 
     // allows test to have the invoke throw an exception
     public Exception invokeHandlerException;

--- a/src/test/java/com/amazonaws/cloudformation/data/create.request-without-caller-credentials.json
+++ b/src/test/java/com/amazonaws/cloudformation/data/create.request-without-caller-credentials.json
@@ -1,0 +1,38 @@
+{
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "responseEndpoint": "cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestContext": {},
+    "requestData": {
+        "platformCredentials": {
+            "accessKeyId": "32IEHAHFIAG538KYASAI",
+            "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
+            "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
+        },
+        "providerCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "providerLogGroupName": "providerLoggingGroupName",
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {
+            "property1": "abc",
+            "property2": 123
+        },
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
+        }
+    },
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Accepting empty/missing `callerCredentials` for types which do not declare a need to access AWS APIs

In this case, the AmazonWebServicesClientProxy will be `null` when passed to handlers



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
