### PR TITLE
Log before and after invoking handlers

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -69,7 +69,10 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
 
         final BaseHandler<CallbackContext> handler = handlers.get(action);
 
-        return handler.handleRequest(proxy, request, callbackContext, loggerProxy);
+        loggerProxy.log(String.format("[%s] invoking handler...", actionName));
+        final ProgressEvent<{{ pojo_name }}, CallbackContext> result = handler.handleRequest(proxy, request, callbackContext, loggerProxy);
+        loggerProxy.log(String.format("[%s] handler invoked", actionName));
+        return result;
     }
 
     public void testEntrypoint(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* People are unlikely to remember to add logging to each of their handlers, and shouldn't need to. This logs as close to handler invocation as possible, which should give customers and us more confidence where errors are happening:

```
Record Handler Progress with Request Id c1ddd928-3d8c-46ad-8365-77984b80416f and Request: [...]
[CREATE] invoking handler...
A
B
[CREATE] handler invoked
Handler returned SUCCESS
Record Handler Progress with Request Id 76cb00ff-6cf5-4b49-82c3-0e66eeff9023 and Request: [...]
```

There's actually a fair amount of code between the record handler progress messages and the invocation itself. Open to changing the format of the message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
