### PR TITLE
Move required method from Configuration to BaseConfiguration

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -253,7 +253,9 @@ class JavaLanguagePlugin(LanguagePlugin):
         LOG.debug("Writing base configuration: %s", path)
         template = self.env.get_template("BaseConfiguration.java")
         contents = template.render(
-            package_name=self.package_name, schema_file_name=project.schema_filename
+            package_name=self.package_name,
+            schema_file_name=project.schema_filename,
+            pojo_name="ResourceModel",
         )
         project.overwrite(path, contents)
 

--- a/python/rpdk/java/templates/BaseConfiguration.java
+++ b/python/rpdk/java/templates/BaseConfiguration.java
@@ -4,10 +4,25 @@ package {{ package_name }};
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.Map;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
 @Data
 @AllArgsConstructor
 public abstract class BaseConfiguration {
 
     protected final String schemaFilename;
 
+    public JSONObject resourceSchemaJSONObject() {
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
+    }
+
+    /**
+     * Providers should override this method if their resource has a 'Tags' property to define resource-level tags
+     * @return
+     */
+    public Map<String, String> resourceDefinedTags(final {{ pojo_name }} resourceModel) {
+        return null;
+    }
 }

--- a/python/rpdk/java/templates/StubConfiguration.java
+++ b/python/rpdk/java/templates/StubConfiguration.java
@@ -9,17 +9,4 @@ class Configuration extends BaseConfiguration {
     public Configuration() {
         super("{{ schema_file_name }}");
     }
-
-    public JSONObject resourceSchemaJSONObject() {
-        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
-    }
-
-    /**
-     * Providers should implement this method if their resource has a 'Tags' property to define resource-level tags
-     * @return
-     */
-    public Map<String, String> resourceDefinedTags(final {{ pojo_name }} resourceModel) {
-        return null;
-    }
-
 }


### PR DESCRIPTION
*Issue #, if available:*  #181 

*Description of changes:* . This change move the required method of configuration from Configuration back to `BaseConfiguration`. So it won't break existing resource.


__Testing__
Verified in SES, `cfn-cli generate` and `mvn package` works fine now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
