### PR TITLE
Additional AWS Context

### DIFF
--- a/python/rpdk/java/templates/HandlerWrapper.java
+++ b/python/rpdk/java/templates/HandlerWrapper.java
@@ -129,8 +129,10 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             .previousResourceState(requestData.getPreviousResourceProperties())
             .desiredResourceTags(getDesiredResourceTags(request))
             .systemTags(request.getRequestData().getSystemTags())
+            .awsAccountId(request.getAwsAccountId())
             .logicalResourceIdentifier(request.getRequestData().getLogicalResourceId())
             .nextToken(request.getNextToken())
+            .region(request.getRegion())
             .build();
     }
 

--- a/src/main/java/com/amazonaws/cloudformation/proxy/ResourceHandlerRequest.java
+++ b/src/main/java/com/amazonaws/cloudformation/proxy/ResourceHandlerRequest.java
@@ -38,6 +38,9 @@ public class ResourceHandlerRequest<T> {
     private T previousResourceState;
     private Map<String, String> desiredResourceTags;
     private Map<String, String> systemTags;
+    private String awsAccountId;
+    private String awsPartition;
     private String logicalResourceIdentifier;
     private String nextToken;
+    private String region;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I was initially resistant to pass AWS-specific context through to handlers but hit an issue I couldn't resolve without it when trying to migrate AWS::SNS::Topic. To construct an ARN for that service's APIs, I need the calling AWS Account and the Region we are operating in. The former cannot be inferred from anything we currently pass. The Region *could* be inferred from Lambda runtime but I don't want to have to introduce that dependency, so I've added both items as context to the `RequestHandlerRequest` payload.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
