### PR TITLE
Rename cfn-cli -> cfn

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,6 +42,6 @@ phases:
       - DIR=$(mktemp -d)
       - cd "$DIR"
       - ls -la
-      - printf "AWS::Foo::Bar\n\n" | cfn-cli init -vv
+      - printf "AWS::Foo::Bar\n\n" | cfn init -vv
       - mvn clean verify
       - ls -la

--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -15,7 +15,7 @@ from .utils import safe_reserved, validate_namespace
 LOG = logging.getLogger(__name__)
 
 OPERATIONS = ("Create", "Read", "Update", "Delete", "List")
-EXECUTABLE = "cfn-cli"
+EXECUTABLE = "cfn"
 
 
 class JavaArchiveNotFoundError(SysExitRecommendedError):


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/310

*Description of changes:* Renames the executable in multiple places in the plugin


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
