### PR TITLE
Use standard retry policy

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudFormationProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudFormationProvider.java
@@ -34,10 +34,7 @@ public class CloudFormationProvider extends AmazonWebServicesProvider {
 
     public CloudFormationClient get() {
         return CloudFormationClient.builder().credentialsProvider(this.getCredentialsProvider())
-            .endpointOverride(this.callbackEndpoint).overrideConfiguration(ClientOverrideConfiguration.builder()
-                // Default Retry Condition of Retry Policy retries on Throttling and ClockSkew
-                // Exceptions
-                .retryPolicy(RetryPolicy.builder().numRetries(16).build()).build())
+            .endpointOverride(this.callbackEndpoint)
             .build();
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*  The 16 times retry is way too much for cloudformation API.  The max time will over 3 minutes, which will cause lambda function timeout.


SDK Default retry policy:  https://sdk.amazonaws.com/java/api/2.0.0/software/amazon/awssdk/core/internal/retry/SdkDefaultRetrySetting.html

 - Strategy:  FullJitterBackoffStrategy
 - Base delay:  Duration.ofMillis(100L);
 - max backoff:  Duration.ofMillis(20000L);
 - Num retries: 3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
