### PR TITLE
Use standard AWS SDK retry policy for CloudWatch/Logs/Events clients

### DIFF
--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudFormationProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudFormationProvider.java
@@ -16,8 +16,6 @@ package com.amazonaws.cloudformation.injection;
 
 import java.net.URI;
 
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 
 public class CloudFormationProvider extends AmazonWebServicesProvider {
@@ -33,8 +31,9 @@ public class CloudFormationProvider extends AmazonWebServicesProvider {
     }
 
     public CloudFormationClient get() {
-        return CloudFormationClient.builder().credentialsProvider(this.getCredentialsProvider())
-            .endpointOverride(this.callbackEndpoint)
-            .build();
+        return CloudFormationClient.builder()
+                .credentialsProvider(this.getCredentialsProvider())
+                .endpointOverride(this.callbackEndpoint)
+                .build();
     }
 }

--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchEventsProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchEventsProvider.java
@@ -14,8 +14,6 @@
 */
 package com.amazonaws.cloudformation.injection;
 
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.cloudwatchevents.CloudWatchEventsClient;
 
 public class CloudWatchEventsProvider extends AmazonWebServicesProvider {
@@ -25,10 +23,6 @@ public class CloudWatchEventsProvider extends AmazonWebServicesProvider {
     }
 
     public CloudWatchEventsClient get() {
-        return CloudWatchEventsClient.builder().overrideConfiguration(ClientOverrideConfiguration.builder()
-            // Default Retry Condition of Retry Policy retries on Throttling and ClockSkew
-            // Exceptions
-            .retryPolicy(RetryPolicy.builder().numRetries(16).build()).build()).credentialsProvider(this.getCredentialsProvider())
-            .build();
+        return CloudWatchEventsClient.builder().credentialsProvider(this.getCredentialsProvider()).build();
     }
 }

--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchLogsProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchLogsProvider.java
@@ -14,8 +14,6 @@
 */
 package com.amazonaws.cloudformation.injection;
 
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 
 public class CloudWatchLogsProvider extends AmazonWebServicesProvider {
@@ -25,11 +23,6 @@ public class CloudWatchLogsProvider extends AmazonWebServicesProvider {
     }
 
     public CloudWatchLogsClient get() {
-        return CloudWatchLogsClient.builder().credentialsProvider(this.getCredentialsProvider())
-            .overrideConfiguration(ClientOverrideConfiguration.builder()
-                // Default Retry Condition of Retry Policy retries on Throttling and ClockSkew
-                // Exceptions
-                .retryPolicy(RetryPolicy.builder().numRetries(16).build()).build())
-            .build();
+        return CloudWatchLogsClient.builder().credentialsProvider(this.getCredentialsProvider()).build();
     }
 }

--- a/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchProvider.java
+++ b/src/main/java/com/amazonaws/cloudformation/injection/CloudWatchProvider.java
@@ -14,8 +14,6 @@
 */
 package com.amazonaws.cloudformation.injection;
 
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 
 public class CloudWatchProvider extends AmazonWebServicesProvider {
@@ -25,11 +23,6 @@ public class CloudWatchProvider extends AmazonWebServicesProvider {
     }
 
     public CloudWatchClient get() {
-        return CloudWatchClient.builder().credentialsProvider(this.getCredentialsProvider())
-            .overrideConfiguration(ClientOverrideConfiguration.builder()
-                // Default Retry Condition of Retry Policy retries on Throttling and ClockSkew
-                // Exceptions
-                .retryPolicy(RetryPolicy.builder().numRetries(16).build()).build())
-            .build();
+        return CloudWatchClient.builder().credentialsProvider(this.getCredentialsProvider()).build();
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #195 

*Description of changes:* . Same as #194 , the CloudWatch clients uses retry with 16 times.   With  16 times,  it will takes max to (0.5 + 1 + 2 + 4 + 8 + 16 + 20 + 9*20 = 231.5 seconds ~= 4 minutes).  This will also cause lambda function timeout in case any  CloudWatch throttling or outage.

__SDK Default retry policy:__ https://sdk.amazonaws.com/java/api/2.0.0/software/amazon/awssdk/core/internal/retry/SdkDefaultRetrySetting.html

Strategy: FullJitterBackoffStrategy
Base delay: Duration.ofMillis(100L);
THROTTLED_BASE_DELAY = Duration.ofMillis(500L);
max backoff: Duration.ofMillis(20000L);
Num retries: 3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
