### PR TITLE
Adding Travis CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,12 +47,6 @@ repos:
     files: "^python/"
 - repo: local
   hooks:
-  - id: git-secrets
-    name: git-secrets
-    description: Run git-secrets
-    entry: git-secrets --scan
-    language: system
-    always_run: true
   - id: pylint-local
     name: pylint-local
     description: Run pylint in the local virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+dist: bionic
+jdk: openjdk11
+cache:
+  - pip
+  - directories:
+    - $HOME/.m2
+env:
+  global:
+  - AWS_REGION="us-east-1"
+  - AWS_DEFAULT_REGION=$AWS_REGION
+before_install:
+  - >
+    pip install --upgrade pip 'attrs==19.2.0'
+    -r https://raw.githubusercontent.com/aws-cloudformation/cloudformation-cli/master/requirements.txt
+install:
+  - pip install .
+
+script:
+  - pre-commit run --all-files
+
+jobs:
+  include:
+    - language: python
+      python: "3.6"
+    - language: python
+      python: "3.7"
+    - language: python
+      python: "3.8"
+    - language: java
+      before_install: skip
+      install: skip
+      script: mvn verify
+    - stage: integ
+      language: python
+      python: "3.6"
+      install:
+        - mvn install
+        - pip install .
+      script:
+        - DIR=$(mktemp -d)
+        - cd "$DIR"
+        - ls -la
+        - printf "AWS::Foo::Bar\n\n" | cfn init -vv
+        - mvn verify
+        - ls -la


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding TravisCI job that should have parity with current codebuild job. 
Planning on adding deployment stages and maybe separating out linting from unit tests, but this seems like a good start. There are four testing jobs that run concurrently, three for the versions of python we support and one for the java portion of the plugin. If these are all successful, an integration stage runs that checks that the two can integrate.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
