### PR TITLE
Enabled CloudWatch Embedded Metric Format Logging

### DIFF
--- a/src/main/java/software/amazon/cloudformation/loggers/CloudWatchLogPublisher.java
+++ b/src/main/java/software/amazon/cloudformation/loggers/CloudWatchLogPublisher.java
@@ -69,6 +69,7 @@ public class CloudWatchLogPublisher extends LogPublisher {
             assert cloudWatchLogsClient != null : "cloudWatchLogsClient was not initialised. "
                 + "You must call refreshClient() first.";
             PutLogEventsResponse putLogEventsResponse = cloudWatchLogsClient.putLogEvents(PutLogEventsRequest.builder()
+                .overrideConfiguration(builder -> builder.putHeader("x-amzn-logs-format", "json/emf"))
                 .sequenceToken(nextSequenceToken).logGroupName(logGroupName).logStreamName(logStreamName)
                 .logEvents(InputLogEvent.builder().message(message).timestamp(new Date().getTime()).build()).build());
 


### PR DESCRIPTION
## Overview
I needed to have some custom metrics to monitor my Resource Handlers behvaiour to get a better understanding of the development experience with the resources.

Fortunately, Cloudwatch has released an [embedded-metrics-format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html) logging feature where you publish logs using a specific format that automatically get exported to metrics and then can be consumed for Dashboards/Alarms too.


## How to support it?
By including a new header in the request to `PutLogEvents` endpoint => `['x-amzn-logs-format'] = 'json/emf'`
This triggers CW to extract metrics from the logs that matches the `emf`

## This PR
This PR is a one-liner that adds the support for the embedded-metrics-format simply by adding the request header mentioned above ^

## Who will be affected?
This wouldn't break any existing plugin consumer because:
* The header is specific for this feature, so it's backward compatible.
* The format is not trivial to have, it's very specific to CloudWatch metrics.
* Even if someone published the logs somehow on this format, nothing would break as they would just see the metrics in their AWS account and they can totally ignore them, similar to what happens with almost all AWS services metrics.
* It doesn't make sense to log something while not wanting to have metrics.

## What value does this change add?
* Custom Monitoring Experience including CW Dashboards and Alarming
* Decreases the number or feature requests you would have for a specific metric as everyone could now implement their own desired metrics :D

## Testing
Tested the package manually with my Resource Providers Packages.
Here's a proof it works:
* A [paste link](https://pastebin.com/ASnAQHy9) to the emitted logs from my providers.
* A [screenshot](https://drive.google.com/open?id=1dqCT_TfnQU4nf85whRuDrc67vzYNvgop) to the generated metrics in my account.