### PR TITLE
Remove repository information from pom to stop http failures

### DIFF
--- a/python/rpdk/java/templates/pom.xml
+++ b/python/rpdk/java/templates/pom.xml
@@ -18,13 +18,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>http://central.maven.org/maven2</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:* #227 

*Description of changes:* Maven deprecated their http endpoint, and the template for a provider's pom.xml had this hard coded. This simply removes the repository information alltogether. Tested with a clean local repo:

```
$ mvn package
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------< com.my.resource.type:my-resource-type-handler >-----------
[INFO] Building my-resource-type-handler 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/cloudformation/aws-cloudformation-rpdk-java-plugin/1.0.2/aws-cloudformation-rpdk-java-plugin-1.0.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/cloudformation/aws-cloudformation-rpdk-java-plugin/1.0.2/aws-cloudformation-rpdk-java-plugin-1.0.2.pom (19 kB at 38 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/bom/2.10.49/bom-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/bom/2.10.49/bom-2.10.49.pom (54 kB at 498 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/aws-sdk-java-pom/2.10.49/aws-sdk-java-pom-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/aws-sdk-java-pom/2.10.49/aws-sdk-java-pom-2.10.49.pom (57 kB at 2.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/cloudformation/aws-cloudformation-resource-schema/2.0.2/aws-cloudformation-resource-schema-2.0.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/cloudformation/aws-cloudformation-resource-schema/2.0.2/aws-cloudformation-resource-schema-2.0.2.pom (13 kB at 702 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.pom (8.8 kB at 177 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/2.10.49/sdk-core-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/2.10.49/sdk-core-2.10.49.pom (10 kB at 593 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/core/2.10.49/core-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/core/2.10.49/core-2.10.49.pom (2.0 kB at 101 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/bom-internal/2.10.49/bom-internal-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/bom-internal/2.10.49/bom-internal-2.10.49.pom (16 kB at 284 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/annotations/2.10.49/annotations-2.10.49.pom
Downloaded from central: https://repo.maven.apache.org/maven2/software/amazon/awssdk/annotations/2.10.49/annotations-2.10.49.pom (1.7 kB at 53 kB/s)
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.832 s
[INFO] Finished at: 2020-01-21T10:27:26-08:00
[INFO] ------------------------------------------------------------------------

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
