### PR TITLE
Add platform version if plugin version is 1.1+

### DIFF
--- a/python/rpdk/java/templates/pom.xml
+++ b/python/rpdk/java/templates/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>1.1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # package_data -> use MANIFEST.in instead
     include_package_data=True,
     zip_safe=True,
-    install_requires=["cloudformation-cli>=0.1,<0.2"],
+    install_requires=["cloudformation-cli>=0.1,<0.2", "defusedxml"],
     python_requires=">=3.6",
     entry_points={"rpdk.v1.languages": ["java = rpdk.java.codegen:JavaLanguagePlugin"]},
     license="Apache License 2.0",


### PR DESCRIPTION
*Issue #, if available:* N/a

*Description of changes:*  This change will include `.platform_version` into package file. It also requires java plugin to be 1.1+.


*Testing*:

```
>cfn submit --dry-run
Dry run complete: <...>aws-ses-configurationset.zip
>unzip -l aws-ses-configurationset.zip
Archive:  aws-ses-configurationset.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     1106  12-05-2019 13:33   schema.json
      432  11-16-2019 22:04   .rpdk-config
 36752971  12-08-2019 11:27   target/aws-ses-configurationset-handler-1.0-SNAPSHOT.jar
     5399  01-29-2020 16:57   pom.xml
        5  01-29-2020 17:16   .platform_version
...
```

If with low version plugin: 

```
>cfn submit --dry-run
Not support aws-cloudformation-rpdk-java-plugin 1.0
Please upgrade to 1.1+.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
