### PR TITLE
Bug fix - Unexpected property duplicates when validating model

### DIFF
--- a/python/rpdk/java/templates/ResourceModel.java
+++ b/python/rpdk/java/templates/ResourceModel.java
@@ -1,6 +1,8 @@
 // This is a generated file. Modifications will be overwritten.
 package {{ package_name }};
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -18,6 +20,7 @@ import org.json.JSONObject;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class {{ model_name|uppercase_first_letter }} {
     @JsonIgnore
     public static final String TYPE_NAME = "{{ type_name }}";


### PR DESCRIPTION
## Issue Description

When a property uses consecutive capitalized string as name in a model schema, it will trigger an unexpected error during handling request while validating template against the schema. Test [template](#test-template) and [schema](#test-schema) have attached.

### Error Displays on CloudFormation Console

```
Model validation failed (#: 4 schema violations found) #: extraneous key [tpscode] is not permitted (#) #: extraneous key [ab] is not permitted (#) #: extraneous key [ttl] is not permitted (#) #: extraneous key [vpcs] is not permitted (#)
```

## Root Cause

In Default, `jackson` uses **getters**, **setters** and **fields** to serialize and deserialize to json, which it will cause duplicated properties when using consecutive capitalized string. As schema validation does not allow additional properties, then it will occur errors as above.

[```{@link software.amazon.cloudformation.resource.Serializer#serialize}```](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/resource/Serializer.java#L77) invoked by [```{@link software.amazon.cloudformation.LambdaWrapper#validateModel}```](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/LambdaWrapper.java#L514)


## Unit Test on Serializer

```java
@Test
public void testModel() throws JsonProcessingException {
    ResourceModel model = ResourceModel.builder()
            .vPCs("VPCs")
            .tPSCode("TPSCode")
            .aB("AB")
            .testCode("TestCode")
            .tTL("TTL")
            .build();
    Serializer serializer = new Serializer();
    System.out.println(serializer.serialize(model));
}
```
Output:
```
{
    "ttl": "TTL",
    "vpcs": "VPCs",
    "ab": "AB",
    "tpscode": "TPSCode",
    "TPSCode": "TPSCode",
    "TestCode": "TestCode",
    "VPCs": "VPCs",
    "TTL": "TTL",
    "AB": "AB"
}
```

## Fix

Turn off `@JsonAutoDetect` on getters and setters to only use the fields as the canonical source of serialization config.

By adding the below annotation before `ResourceModel` Class would fix the issue.
```java
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
```

## After Fix

Unit test output displays as expected, Manual test has passed as well.
```
{
    "TPSCode": "TPSCode",
    "TestCode": "TestCode",
    "VPCs": "VPCs",
    "TTL": "TTL",
    "AB": "AB"
}
```

### Generated Resource Model After Fix
```java
// This is a generated file. Modifications will be overwritten.
package com.test.duplicate.cases;

import com.fasterxml.jackson.annotation.JsonAutoDetect;
import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
import com.fasterxml.jackson.annotation.JsonIgnore;
import com.fasterxml.jackson.annotation.JsonProperty;
import java.util.Map;
import java.util.List;
import java.util.ArrayList;
import java.util.Set;
import lombok.AllArgsConstructor;
import lombok.Builder;
import lombok.Data;
import lombok.NoArgsConstructor;
import org.json.JSONObject;


@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ResourceModel {
    @JsonIgnore
    public static final String TYPE_NAME = "Test::Duplicate::Cases";

    @JsonIgnore
    public static final String IDENTIFIER_KEY_TPSCODE = "/properties/TPSCode";

    @JsonProperty("TPSCode")
    private String tPSCode;

    @JsonProperty("TestCode")
    private String testCode;

    @JsonProperty("VPCs")
    private String vPCs;

    @JsonProperty("TTL")
    private String tTL;

    @JsonProperty("AB")
    private String aB;

    @JsonIgnore
    public JSONObject getPrimaryIdentifier() {
        final JSONObject identifier = new JSONObject();
        if (this.getTPSCode() != null) {
            identifier.put(IDENTIFIER_KEY_TPSCODE, this.getTPSCode());
        }

        // only return the identifier if it can be used, i.e. if all components are present
        return identifier.length() == 1 ? identifier : null;
    }

    @JsonIgnore
    public List<JSONObject> getAdditionalIdentifiers() {
        final List<JSONObject> identifiers = new ArrayList<JSONObject>();
        // only return the identifiers if any can be used
        return identifiers.isEmpty() ? null : identifiers;
    }
}
```

## Alternative Fix

> Not using this because it has global impact

We can also solve this by setting visibility in Global config for ```ObjectMapper``` [{@See Serializer#**static initialization block**}](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/resource/Serializer.java#L64)

```java
OBJECT_MAPPER.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
```

## Test Schema

```json
{
    "typeName": "Test::Duplicate::Cases",
    "description": "An example resource schema demonstrating some basic constructs and validation rules.",
    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
    "properties": {
        "TPSCode": {
            "description": "A TPS Code is automatically generated on creation and assigned as the unique identifier.",
            "type": "string"
        },
        "TestCode": {
            "type": "string"
        },
        "VPCs": {
            "type": "string"
        },
        "TTL": {
            "type": "string"
        },
        "AB": {
            "type": "string"
        }
    },
    "additionalProperties": false,
    "readOnlyProperties": [
        "/properties/TPSCode"
    ],
    "primaryIdentifier": [
        "/properties/TPSCode"
    ],
    "handlers": {
        "create": {
            "permissions": [
                "initech:CreateReport"
            ]
        },
        "read": {
            "permissions": [
                "initech:DescribeReport"
            ]
        },
        "update": {
            "permissions": [
                "initech:UpdateReport"
            ]
        },
        "delete": {
            "permissions": [
                "initech:DeleteReport"
            ]
        },
        "list": {
            "permissions": [
                "initech:ListReports"
            ]
        }
    }
}
```

## Test template

```yml
Resources:
  DuplicateTest:
    Type: Test::Duplicate::Cases
    Properties:
      VPCs : test
      TPSCode: test
      AB: test
      TTL: test
      TestCode: test
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
