### PR TITLE
Issue fix - Duplicated subproperties causing validation errors

### DIFF
--- a/python/rpdk/java/templates/POJO.java
+++ b/python/rpdk/java/templates/POJO.java
@@ -1,6 +1,9 @@
 // This is a generated file. Modifications will be overwritten.
 package {{ package_name }};
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.List;
@@ -15,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class {{ model_name|uppercase_first_letter }} {
     {% for name, type in properties.items() %}
     @JsonProperty("{{ name }}")


### PR DESCRIPTION
## Issue Description

When a **sub-property** uses consecutive capitalized string as name in schema, it will trigger an unexpected error in handling request while validating template against the schema. Test [template](#test-template) and [schema](#test-schema) have attached

### Error displays on CloudFormation console

```
Model validation failed (#/VPCs/0: 2 schema violations found) #/VPCs/0: extraneous key [vpcregion] is not permitted (#/VPCs/0) #/VPCs/0: extraneous key [vpcid] is not permitted (#/VPCs/0)
```

## Root cause

Same root cause as [**PR#235**](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/235). Duplicated sub-properties being generated unexpectedly. Since additional properties in a sub-property are disallowed as well, then it will occur errors as above.

[```{@link software.amazon.cloudformation.resource.Serializer#serialize}```](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/resource/Serializer.java#L76) invoked by [```{@link software.amazon.cloudformation.LambdaWrapper#validateModel}```](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/LambdaWrapper.java#L510)

## Unit test on Serializer & Validator

```java
@Test
public void testModel() throws JsonProcessingException {
    ResourceModel model = ResourceModel.builder()
            .tPSCode("TPSCode")
            .vPCs(Arrays.asList(VPC.builder().vPCId("id").vPCRegion("region").build()))
            .build();
    Serializer serializer = new Serializer();
    final String jsonString = serializer.serialize(model);

    System.out.println(jsonString);

    Validator validator = new Validator();
    validator.validateObject(new JSONObject(jsonString),
            new JSONObject(new JSONTokener(this.getClass().getResourceAsStream("/test-duplicate-cases.json"))));
}
```
Output:
```
{"TPSCode":"TPSCode","VPCs":[{"vpcid":"id","vpcregion":"region","VPCId":"id","VPCRegion":"region"}]}

software.amazon.cloudformation.resource.exceptions.ValidationException: #/VPCs/0: 2 schema violations found
```


## Fix

Turn off `@JsonAutoDetect` on getters and setters to only use the fields as the canonical source of serialization config.

Since SubProperties are generated by `POJO.java` template. [Ref: codegen.py](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/python/rpdk/java/codegen.py#L267-L290)

By adding the below annotation before `POJO` Class template would fix the issue.
```java
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
```

## After Fix

* Unit test output displays as expected.
    ```
    {"TPSCode":"TPSCode","VPCs":[{"VPCId":"id","VPCRegion":"region"}]}


    Process finished with exit code 0
    ```
* Manual test against CloudFormation has passed as well.

## Test Schema

```json
{
    "typeName": "Test::Duplicate::Cases",
    "description": "An example resource schema demonstrating some basic constructs and validation rules.",
    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
    "definitions": {
        "VPC": {
            "type": "object",
            "additionalProperties": false,
            "properties": {
                "VPCId": {
                    "type": "string"
                },
                "VPCRegion": {
                    "type": "string"
                }
            },
            "required": [
                "VPCId",
                "VPCRegion"
            ]
        }
    },
    "properties": {
        "TPSCode": {
            "type": "string"
        },
        "VPCs": {
            "type": "array",
            "items": {
                "$ref": "#/definitions/VPC"
            }
        }
    },
    "additionalProperties": false,
    "readOnlyProperties": [
        "/properties/TPSCode"
    ],
    "primaryIdentifier": [
        "/properties/TPSCode"
    ],
    "handlers": {
        "create": {
            "permissions": [
                "initech:CreateReport"
            ]
        },
        "read": {
            "permissions": [
                "initech:DescribeReport"
            ]
        },
        "update": {
            "permissions": [
                "initech:UpdateReport"
            ]
        },
        "delete": {
            "permissions": [
                "initech:DeleteReport"
            ]
        },
        "list": {
            "permissions": [
                "initech:ListReports"
            ]
        }
    }
}
```

## Test template

```yml
Resources:
  DuplicateTest:
    Type: Test::Duplicate::Cases
    Properties:
      TPSCode: test
      VPCs : 
        - VPCId: id
          VPCRegion: region
```