### PR TITLE
Change Integer -> Long

### DIFF
--- a/python/rpdk/java/resolver.py
+++ b/python/rpdk/java/resolver.py
@@ -2,7 +2,7 @@ from rpdk.core.jsonutils.resolver import UNDEFINED, ContainerType
 
 PRIMITIVE_TYPES = {
     "string": "String",
-    "integer": "Integer",
+    "integer": "Long",
     "boolean": "Boolean",
     "number": "Double",
     UNDEFINED: "Object",


### PR DESCRIPTION
*Issue #, if available:* #151 

*Description of changes:* This changes the codegen to generate a Long instead of Integer when generating code for schemas of type "integer". Going to open this as a draft PR and document any testing done to ensure this is a safe change to make and if not encorporate a version bump to signify the difference. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
