### PR TITLE
Allow for automated call graph generation to keep contexts unique

### DIFF
--- a/src/main/java/software/amazon/cloudformation/proxy/CallChain.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/CallChain.java
@@ -53,7 +53,7 @@ public interface CallChain {
      * @param <ModelT> the model object being worked on
      * @param <CallbackT> the callback context
      */
-    interface Initiator<ClientT, ModelT, CallbackT extends StdCallbackContext> {
+    interface Initiator<ClientT, ModelT, CallbackT extends StdCallbackContext> extends RequestMaker<ClientT, ModelT, CallbackT> {
         /**
          * Each service call must be first initiated. Every call is provided a separate
          * name called call graph. This is essential from both a tracing perspective as
@@ -73,6 +73,11 @@ public interface CallChain {
          * @return the callback context associated with API initiator, Can not be null
          */
         CallbackT getCallbackContext();
+
+        /**
+         * @return logger associated to log messages
+         */
+        Logger getLogger();
 
         /**
          * Can rebind a new model to the call chain while retaining the client and

--- a/src/main/java/software/amazon/cloudformation/proxy/CallGraphNameGenerator.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/CallGraphNameGenerator.java
@@ -12,17 +12,11 @@
 * express or implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */
-package software.amazon.cloudformation.proxy.service;
+package software.amazon.cloudformation.proxy;
 
-import software.amazon.awssdk.core.SdkClient;
+import java.util.function.Function;
 
-public interface ServiceClient extends SdkClient {
-
-    default String serviceName() {
-        return "serviceClient";
-    }
-
-    CreateResponse createRepository(CreateRequest r);
-
-    DescribeResponse describeRepository(DescribeRequest r);
+@FunctionalInterface
+public interface CallGraphNameGenerator<ModelT, RequestT, ClientT, CallbackT extends StdCallbackContext> {
+    String callGraph(String incoming, ModelT model, Function<ModelT, RequestT> reqMaker, ClientT client, CallbackT context);
 }

--- a/src/main/java/software/amazon/cloudformation/proxy/StdCallbackContext.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/StdCallbackContext.java
@@ -32,9 +32,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -270,6 +274,39 @@ public class StdCallbackContext {
     @SuppressWarnings("unchecked")
     public <ResponseT> ResponseT response(String callGraph) {
         return (ResponseT) callGraphs.get(callGraph + ".response");
+    }
+
+    @SuppressWarnings("unchecked")
+    public <RequestT> RequestT findFirstRequestByContains(String contains) {
+        return (RequestT) findFirst((key) -> key.contains(contains) && key.endsWith(".request"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <RequestT> List<RequestT> findAllRequestByContains(String contains) {
+        return (List<RequestT>) findAll((key) -> key.contains(contains) && key.endsWith(".request"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <ResponseT> ResponseT findFirstResponseByContains(String contains) {
+        return (ResponseT) findFirst((key) -> key.contains(contains) && key.endsWith(".response"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <ResponseT> List<ResponseT> findAllResponseByContains(String contains) {
+        return (List<ResponseT>) findAll((key) -> key.contains(contains) && key.endsWith(".response"));
+    }
+
+    Object findFirst(Predicate<String> contains) {
+        Objects.requireNonNull(contains);
+        return callGraphs.entrySet().stream().filter(e -> contains.test(e.getKey())).findFirst().map(Map.Entry::getValue)
+            .orElse(null);
+
+    }
+
+    List<Object> findAll(Predicate<String> contains) {
+        Objects.requireNonNull(contains);
+        return callGraphs.entrySet().stream().filter(e -> contains.test(e.getKey())).map(Map.Entry::getValue)
+            .collect(Collectors.toList());
     }
 
     <RequestT, ResponseT, ClientT, ModelT, CallbackT extends StdCallbackContext>


### PR DESCRIPTION
*Description of changes:*

Allow for automated call graph generation to keep contexts unique
inside StdCallbackContext for replay deduping. Now developers do not need to
provide a name when calling services. One is auto-generated with the 
SdkClient service name and IAM action named from Request type used. 

```java
     ProgressEvent<Model, StdCallbackContext> result = initiator
        .translateToServiceRequest(m -> )
        .makeServiceCall((r, c) -> c.injectCredentialsAndInvokeV2(r, c.client()::createRepository))
        .success();
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
