### PR TITLE
Removing large errors from logs and stack events

### DIFF
--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -563,8 +563,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
             int callbackDelayMinutes = Math.abs(handlerResponse.getCallbackDelaySeconds() / 60);
             this.scheduler.rescheduleAfterMinutes(context.getInvokedFunctionArn(), callbackDelayMinutes, request);
         } catch (final Throwable e) {
-            this.log(String.format("Failed to schedule re-invoke, caused by %s", e.toString()));
-            handlerResponse.setMessage(e.getMessage());
+            handlerResponse.setMessage("Failed to schedule re-invoke.");
             handlerResponse.setStatus(OperationStatus.FAILED);
             handlerResponse.setErrorCode(HandlerErrorCode.InternalFailure);
         }

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -158,7 +158,6 @@ public class LambdaWrapperTest {
 
         assertThat(handlerResponse.getBearerToken()).isEqualTo(expected.getBearerToken());
         assertThat(handlerResponse.getErrorCode()).isEqualTo(expected.getErrorCode());
-        assertThat(handlerResponse.getMessage()).isEqualTo(expected.getMessage());
         assertThat(handlerResponse.getNextToken()).isEqualTo(expected.getNextToken());
         assertThat(handlerResponse.getOperationStatus()).isEqualTo(expected.getOperationStatus());
         assertThat(handlerResponse.getStabilizationData()).isEqualTo(expected.getStabilizationData());


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Certain error messages are too verbose and polluting stack events. This is a quick fix to address that issue while we improve handling.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
