### PR TITLE
removing AsyncClient and assignment in return statement in ClientBuilder

### DIFF
--- a/python/rpdk/java/templates/init/guided_aws/ClientBuilder.java
+++ b/python/rpdk/java/templates/init/guided_aws/ClientBuilder.java
@@ -1,18 +1,18 @@
 package {{ package_name }};
 
 import software.amazon.awssdk.core.SdkClient;
-// TODO: replace all usage of SdkClient with your service client type, e.g; YourServiceAsyncClient
-// import software.amazon.awssdk.services.yourservice.YourServiceAsyncClient;
+// TODO: replace all usage of SdkClient with your service client type, e.g; YourServiceClient
+// import software.amazon.awssdk.services.yourservice.YourServiceClient;
 // import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
   /*
-  TODO: uncomment the following, replacing YourServiceAsyncClient with your service client name
+  TODO: uncomment the following, replacing YourServiceClient with your service client name
   It is recommended to use static HTTP client so less memory is consumed
   e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/blob/master/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ClientBuilder.java#L9
 
-  public static YourServiceAsyncClient getClient() {
-    return YourServiceAsyncClient SERVICE_CLIENT = YourServiceAsyncClient.builder()
+  public static YourServiceClient getClient() {
+    return YourServiceClient.builder()
               .httpClient(LambdaWrapper.HTTP_CLIENT)
               .build();
   }


### PR DESCRIPTION
[`LambdaWrapper.HTTP_CLIENT`](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/52114e3be5f8f810635c9c2bb8bf5560708823c1/src/main/java/software/amazon/cloudformation/LambdaWrapper.java#L83) is `SdkHttpClient`, not `SdkAsyncHttpClient`, so the code needs to be changed one way or the other

ditched `Async` citing the prior art for [`AWS::SES::ConfigurationSet`](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ses/blob/master/aws-ses-configurationset/src/main/java/software/amazon/ses/configurationset/ClientBuilder.java) and [`AWS::Logs::LogGroup`](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/blob/master/aws-logs-loggroup/src/main/java/software/amazon/logs/loggroup/ClientBuilder.java), but no strong opinion either way