### PR TITLE
Fix call graph for stub update handler

### DIFF
--- a/python/rpdk/java/templates/init/guided_aws/StubUpdateHandler.java
+++ b/python/rpdk/java/templates/init/guided_aws/StubUpdateHandler.java
@@ -35,7 +35,7 @@ public class UpdateHandler extends BaseHandlerStd {
             // STEP 1 [first update/stabilize progress chain - required for resource update]
             .then(progress ->
                 // STEP 1.0 [initialize a proxy context]
-                proxy.initiate("AWS-Foo-Bar::Update", proxyClient, model, callbackContext)
+                proxy.initiate("{{ call_graph }}::{{ operation }}", proxyClient, model, callbackContext)
 
                     // STEP 1.1 [TODO: construct a body of a request]
                     .translateToServiceRequest(Translator::translateToFirstUpdateRequest)
@@ -53,7 +53,7 @@ public class UpdateHandler extends BaseHandlerStd {
             // STEP 2 [second update/stabilize progress chain]
             .then(progress ->
                     // STEP 2.0 [initialize a proxy context]
-                    proxy.initiate("AWS-Foo-Bar::Update", proxyClient, model, callbackContext)
+                    proxy.initiate("{{ call_graph }}::{{ operation }}", proxyClient, model, callbackContext)
 
                     // STEP 2.1 [TODO: construct a body of a request]
                     .translateToServiceRequest(Translator::translateToSecondUpdateRequest)


### PR DESCRIPTION
*Issue #, if available:* N/A 

*Description of changes:* Fix call graph for stub update handler. Note I have NOT tested this change because I don't know how. I only copied what the other stub handlers have ([example](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/python/rpdk/java/templates/init/guided_aws/StubReadHandler.java#L35))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
