### PR TITLE
Add proxy methods to support invocation for inputstream/bytes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,10 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->

--- a/python/rpdk/java/templates/init/guided_aws/AbstractTestBase.java
+++ b/python/rpdk/java/templates/init/guided_aws/AbstractTestBase.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
@@ -41,6 +43,18 @@ public class AbstractTestBase {
       IterableT
       injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction) {
         return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+      }
+
+      @Override
+      public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT>
+      injectCredentialsAndInvokeV2InputStream(RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT>
+      injectCredentialsAndInvokeV2Bytes(RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+        throw new UnsupportedOperationException();
       }
 
       @Override

--- a/src/main/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxy.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxy.java
@@ -40,6 +40,8 @@ import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.exception.RetryableException;
@@ -122,6 +124,22 @@ public class AmazonWebServicesClientProxy implements CallChain {
                 IterableT
                 injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction) {
                 return AmazonWebServicesClientProxy.this.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                ResponseInputStream<ResponseT>
+                injectCredentialsAndInvokeV2InputStream(RequestT request,
+                                                        Function<RequestT, ResponseInputStream<ResponseT>> requestFunction) {
+                return AmazonWebServicesClientProxy.this.injectCredentialsAndInvokeV2InputStream(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                ResponseBytes<ResponseT>
+                injectCredentialsAndInvokeV2Bytes(RequestT request,
+                                                  Function<RequestT, ResponseBytes<ResponseT>> requestFunction) {
+                return AmazonWebServicesClientProxy.this.injectCredentialsAndInvokeV2Bytes(request, requestFunction);
             }
 
             @Override
@@ -497,6 +515,44 @@ public class AmazonWebServicesClientProxy implements CallChain {
     public <RequestT extends AwsRequest, ResultT extends AwsResponse, IterableT extends SdkIterable<ResultT>>
         IterableT
         injectCredentialsAndInvokeIterableV2(final RequestT request, final Function<RequestT, IterableT> requestFunction) {
+
+        AwsRequestOverrideConfiguration overrideConfiguration = AwsRequestOverrideConfiguration.builder()
+            .credentialsProvider(v2CredentialsProvider).build();
+
+        @SuppressWarnings("unchecked")
+        RequestT wrappedRequest = (RequestT) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+
+        try {
+            return requestFunction.apply(wrappedRequest);
+        } catch (final Throwable e) {
+            loggerProxy.log(String.format("Failed to execute remote function: {%s}", e.getMessage()));
+            throw e;
+        }
+    }
+
+    public <RequestT extends AwsRequest, ResultT extends AwsResponse>
+        ResponseInputStream<ResultT>
+        injectCredentialsAndInvokeV2InputStream(final RequestT request,
+                                                final Function<RequestT, ResponseInputStream<ResultT>> requestFunction) {
+
+        AwsRequestOverrideConfiguration overrideConfiguration = AwsRequestOverrideConfiguration.builder()
+            .credentialsProvider(v2CredentialsProvider).build();
+
+        @SuppressWarnings("unchecked")
+        RequestT wrappedRequest = (RequestT) request.toBuilder().overrideConfiguration(overrideConfiguration).build();
+
+        try {
+            return requestFunction.apply(wrappedRequest);
+        } catch (final Throwable e) {
+            loggerProxy.log(String.format("Failed to execute remote function: {%s}", e.getMessage()));
+            throw e;
+        }
+    }
+
+    public <RequestT extends AwsRequest, ResultT extends AwsResponse>
+        ResponseBytes<ResultT>
+        injectCredentialsAndInvokeV2Bytes(final RequestT request,
+                                          final Function<RequestT, ResponseBytes<ResultT>> requestFunction) {
 
         AwsRequestOverrideConfiguration overrideConfiguration = AwsRequestOverrideConfiguration.builder()
             .credentialsProvider(v2CredentialsProvider).build();

--- a/src/main/java/software/amazon/cloudformation/proxy/ProxyClient.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/ProxyClient.java
@@ -18,6 +18,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 
 /**
@@ -93,6 +95,45 @@ public interface ProxyClient<ClientT> {
     <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>>
         IterableT
         injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction);
+
+    /**
+     * This is a synchronous version of making API calls which implement
+     * ResponseInputStream in the SDKv2
+     *
+     * @param request, the AWS service request that we need to make
+     * @param requestFunction, this is a Lambda closure that provide the actual API
+     *            that needs to be invoked.
+     * @param <RequestT> the request type
+     * @param <ResponseT> the response from the request
+     * @return the response if successful. Else it will propagate all
+     *         {@link software.amazon.awssdk.awscore.exception.AwsServiceException}
+     *         that is thrown or
+     *         {@link software.amazon.awssdk.core.exception.SdkClientException} if
+     *         there is client side problem
+     */
+    <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+        ResponseInputStream<ResponseT>
+        injectCredentialsAndInvokeV2InputStream(RequestT request,
+                                                Function<RequestT, ResponseInputStream<ResponseT>> requestFunction);
+
+    /**
+     * This is a synchronous version of making API calls which implement
+     * ResponseBytes in the SDKv2
+     *
+     * @param request, the AWS service request that we need to make
+     * @param requestFunction, this is a Lambda closure that provide the actual API
+     *            that needs to be invoked.
+     * @param <RequestT> the request type
+     * @param <ResponseT> the response from the request
+     * @return the response if successful. Else it will propagate all
+     *         {@link software.amazon.awssdk.awscore.exception.AwsServiceException}
+     *         that is thrown or
+     *         {@link software.amazon.awssdk.core.exception.SdkClientException} if
+     *         there is client side problem
+     */
+    <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+        ResponseBytes<ResponseT>
+        injectCredentialsAndInvokeV2Bytes(RequestT request, Function<RequestT, ResponseBytes<ResponseT>> requestFunction);
 
     /**
      * @return the actual AWS service client that we need to use to provide the


### PR DESCRIPTION
### What are we changing?
* Added two proxy methods to extend `ResponseInputStream<AwsResponse>` and `ResponseBytes<AwsResponse>`

### Why are we changing?
* A few uncommon AWS APIs like `S3::GetObject` requires AWS Credentials Provider to authenticate the API requests

### What happens if we do not change?
* Customers have to mimic a dummy request to extract out the credentials. for example, [StackSet needs to validate the content in S3](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/pull/6/files/1e7ca3fc2d9223b7ac244ca08258991b4216e2b8#diff-3f62f9b7133240c794680f6a69c6b645)

### How did we test?
* Manually tested the changes locally.
* Associated Unit tests pass.
* Create/Update/Delete succeed.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
