### PR TITLE
Fix base exception message

### DIFF
--- a/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
@@ -26,7 +26,7 @@ public abstract class BaseHandlerException extends RuntimeException {
 
     protected BaseHandlerException(final Throwable cause,
                                    final HandlerErrorCode errorCode) {
-        super(null, cause);
+        super(cause.getMessage(), cause);
         this.errorCode = errorCode;
     }
 
@@ -34,6 +34,12 @@ public abstract class BaseHandlerException extends RuntimeException {
                                    final Throwable cause,
                                    final HandlerErrorCode errorCode) {
         super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    protected BaseHandlerException(final String message,
+                                   final HandlerErrorCode errorCode) {
+        super(message);
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
@@ -26,7 +26,7 @@ public abstract class BaseHandlerException extends RuntimeException {
 
     protected BaseHandlerException(final Throwable cause,
                                    final HandlerErrorCode errorCode) {
-        super(cause);
+        super(cause.getMessage(), cause);
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
@@ -26,7 +26,7 @@ public abstract class BaseHandlerException extends RuntimeException {
 
     protected BaseHandlerException(final Throwable cause,
                                    final HandlerErrorCode errorCode) {
-        super(cause.getMessage(), cause);
+        super(cause);
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidCredentialsException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidCredentialsException.java
@@ -22,10 +22,10 @@ public class CfnInvalidCredentialsException extends BaseHandlerException {
     private static final HandlerErrorCode ERROR_CODE = HandlerErrorCode.InvalidCredentials;
 
     public CfnInvalidCredentialsException() {
-        this(null);
+        super(ERROR_CODE.getMessage(), ERROR_CODE);
     }
 
     public CfnInvalidCredentialsException(final Throwable cause) {
-        super(ERROR_CODE.getMessage(), cause, ERROR_CODE);
+        super(cause, ERROR_CODE);
     }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnAccessDeniedExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnAccessDeniedExceptionTests.java
@@ -48,4 +48,11 @@ public class CfnAccessDeniedExceptionTests {
             throw new CfnAccessDeniedException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.AccessDenied, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnAccessDeniedException_errorMessage() {
+        assertThatExceptionOfType(CfnAccessDeniedException.class).isThrownBy(() -> {
+            throw new CfnAccessDeniedException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnAlreadyExistsExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnAlreadyExistsExceptionTests.java
@@ -79,4 +79,11 @@ public class CfnAlreadyExistsExceptionTests {
             throw new CfnAlreadyExistsException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.AlreadyExists, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnAlreadyExistsException_errorMessage() {
+        assertThatExceptionOfType(CfnAlreadyExistsException.class).isThrownBy(() -> {
+            throw new CfnAlreadyExistsException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceExceptionTests.java
@@ -49,4 +49,11 @@ public class CfnGeneralServiceExceptionTests {
             throw new CfnGeneralServiceException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.GeneralServiceException, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnGeneralServiceException_errorMessage() {
+        assertThatExceptionOfType(CfnGeneralServiceException.class).isThrownBy(() -> {
+            throw new CfnGeneralServiceException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidCredentialsExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidCredentialsExceptionTests.java
@@ -31,7 +31,7 @@ public class CfnInvalidCredentialsExceptionTests {
     public void cfnInvalidCredentialsException_singleArgConstructorHasMessage() {
         assertThatExceptionOfType(CfnInvalidCredentialsException.class).isThrownBy(() -> {
             throw new CfnInvalidCredentialsException(new RuntimeException());
-        }).withCauseInstanceOf(RuntimeException.class).withMessageContaining("Invalid credentials");
+        }).withCauseInstanceOf(RuntimeException.class).withMessage(null);
     }
 
     @Test
@@ -46,5 +46,12 @@ public class CfnInvalidCredentialsExceptionTests {
         assertThatExceptionOfType(CfnInvalidCredentialsException.class).isThrownBy(() -> {
             throw new CfnInvalidCredentialsException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.InvalidCredentials, exception.getErrorCode()));
+    }
+
+    @Test
+    public void cfnInvalidCredentialsException_errorMessage() {
+        assertThatExceptionOfType(CfnInvalidCredentialsException.class).isThrownBy(() -> {
+            throw new CfnInvalidCredentialsException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
     }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidRequestExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidRequestExceptionTests.java
@@ -48,4 +48,11 @@ public class CfnInvalidRequestExceptionTests {
             throw new CfnInvalidRequestException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.InvalidRequest, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnInvalidRequestException_errorCodeMessage() {
+        assertThatExceptionOfType(CfnInvalidRequestException.class).isThrownBy(() -> {
+            throw new CfnInvalidRequestException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnNetworkFailureExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnNetworkFailureExceptionTests.java
@@ -48,4 +48,11 @@ public class CfnNetworkFailureExceptionTests {
             throw new CfnNetworkFailureException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.NetworkFailure, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnNetworkFailureException_errorMessage() {
+        assertThatExceptionOfType(CfnNetworkFailureException.class).isThrownBy(() -> {
+            throw new CfnNetworkFailureException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnNotFoundExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnNotFoundExceptionTests.java
@@ -79,4 +79,11 @@ public class CfnNotFoundExceptionTests {
             throw new CfnNotFoundException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.NotFound, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnNotFoundException_errorMessage() {
+        assertThatExceptionOfType(CfnNotFoundException.class).isThrownBy(() -> {
+            throw new CfnNotFoundException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedExceptionTests.java
@@ -49,4 +49,11 @@ public class CfnNotStabilizedExceptionTests {
             throw new CfnNotStabilizedException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.NotStabilized, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnNotStabilizedException_errorMessage() {
+        assertThatExceptionOfType(CfnNotStabilizedException.class).isThrownBy(() -> {
+            throw new CfnNotStabilizedException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnNotUpdatableExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnNotUpdatableExceptionTests.java
@@ -49,4 +49,11 @@ public class CfnNotUpdatableExceptionTests {
             throw new CfnNotUpdatableException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.NotUpdatable, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnNotUpdatableException_errorMessage() {
+        assertThatExceptionOfType(CfnNotUpdatableException.class).isThrownBy(() -> {
+            throw new CfnNotUpdatableException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnServiceInternalErrorExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnServiceInternalErrorExceptionTests.java
@@ -49,4 +49,11 @@ public class CfnServiceInternalErrorExceptionTests {
             throw new CfnServiceInternalErrorException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.ServiceInternalError, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnServiceInternalErrorException_errorMessage() {
+        assertThatExceptionOfType(CfnServiceInternalErrorException.class).isThrownBy(() -> {
+            throw new CfnServiceInternalErrorException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnServiceLimitExceededExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnServiceLimitExceededExceptionTests.java
@@ -49,4 +49,11 @@ public class CfnServiceLimitExceededExceptionTests {
             throw new CfnServiceLimitExceededException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.ServiceLimitExceeded, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnServiceLimitExceededException_errorMessage() {
+        assertThatExceptionOfType(CfnServiceLimitExceededException.class).isThrownBy(() -> {
+            throw new CfnServiceLimitExceededException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnThrottlingExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnThrottlingExceptionTests.java
@@ -48,4 +48,11 @@ public class CfnThrottlingExceptionTests {
             throw new CfnThrottlingException(new RuntimeException());
         }).satisfies(exception -> assertEquals(HandlerErrorCode.Throttling, exception.getErrorCode()));
     }
+
+    @Test
+    public void cfnThrottlingException_errorMessage() {
+        assertThatExceptionOfType(CfnThrottlingException.class).isThrownBy(() -> {
+            throw new CfnThrottlingException(new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*  #243 

*Description of changes:*. Fix the error message issue for BaseHandlerException. 

Cloudformation service doesn't like empty message exception, use the cause exception as default exception message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
