### PR TITLE
Log error when failing to schedule re-invocation

### DIFF
--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -572,6 +572,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
             int callbackDelayMinutes = Math.abs(handlerResponse.getCallbackDelaySeconds() / 60);
             this.scheduler.rescheduleAfterMinutes(context.getInvokedFunctionArn(), callbackDelayMinutes, request);
         } catch (final Throwable e) {
+            log(String.format("Failed to schedule re-invoke, %s", e.getMessage()));
             handlerResponse.setMessage("Failed to schedule re-invoke.");
             handlerResponse.setStatus(OperationStatus.FAILED);
             handlerResponse.setErrorCode(HandlerErrorCode.InternalFailure);


### PR DESCRIPTION
*Description of changes:*

At the moment, when the handler fails to schedule a re-invocation the error message is not displayed in any manner and is hard to guess what was the error of the stack when the handlers succeed on "handling" the resource operation.

This at least will make it easier for the operator to know the details of the error.

> Not a required change, just making life easier in the meantime

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
