### PR TITLE
Retains writeOnlyProperties through reinvocations

### DIFF
--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -186,7 +186,6 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         this.lambdaLogger = context.getLogger();
         ProgressEvent<ResourceT, CallbackT> handlerResponse = null;
         HandlerRequest<ResourceT, CallbackT> request = null;
-        String bearerToken = null;
         scrubFiles();
         try {
             if (inputStream == null) {
@@ -374,7 +373,13 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         ResourceT model = response.getResourceModel();
         if (model != null) {
             JSONObject modelObject = new JSONObject(this.serializer.serialize(model));
-            ResourceTypeSchema.load(provideResourceSchemaJSONObject()).removeWriteOnlyProperties(modelObject);
+
+            // strip write only properties on final results, we will need the intact model
+            // while provisioning
+            if (response.getStatus() != OperationStatus.IN_PROGRESS) {
+                ResourceTypeSchema.load(provideResourceSchemaJSONObject()).removeWriteOnlyProperties(modelObject);
+            }
+
             ResourceT sanitizedModel = this.serializer.deserializeStrict(modelObject.toString(), getModelTypeReference());
 
             response.setResourceModel(sanitizedModel);

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -330,7 +330,6 @@ public class LambdaWrapperTest {
 
     @Test
     public void invokeHandler_DependenciesInitialised_CompleteSynchronously_returnsSuccess() throws IOException {
-        final Action action = Action.CREATE;
         final WrapperOverride wrapper = new WrapperOverride();
         final TestModel model = new TestModel();
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Protocol v2.0.0 changes mean that when we strip `writeOnlyProperties` they are not passed back on reinvoke. This PR addresses that issue - the redaction is only required for completed `ProgressEvents`, in particular results of direct `Read` requests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
