### PR TITLE
Bump required cloudformation-cli to 0.1.4

### DIFF
--- a/python/rpdk/java/__init__.py
+++ b/python/rpdk/java/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # package_data -> use MANIFEST.in instead
     include_package_data=True,
     zip_safe=True,
-    install_requires=["cloudformation-cli>=0.1,<0.2"],
+    install_requires=["cloudformation-cli>=0.1.4,<0.2"],
     python_requires=">=3.6",
     entry_points={"rpdk.v1.languages": ["java = rpdk.java.codegen:JavaLanguagePlugin"]},
     license="Apache License 2.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Java plugin is using MULTIPLE type feature which is only available in cloudformation-cli 0.1.4(https://github.com/aws-cloudformation/cloudformation-cli/releases/tag/v0.1.4).  

This PR will bump the cloudformation-cli requirement to 0.1.4 as well as bump java plugin version to 2.0.1 to release this fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
