### PR TITLE
Use standard AWS SDK exception message

### DIFF
--- a/src/main/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxy.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxy.java
@@ -572,8 +572,7 @@ public class AmazonWebServicesClientProxy implements CallChain {
         if (e instanceof AwsServiceException) {
             AwsServiceException sdkException = (AwsServiceException) e;
             AwsErrorDetails details = sdkException.awsErrorDetails();
-            String errMsg = "Exception=[" + sdkException.getClass() + "] " + "ErrorCode=[" + details.errorCode()
-                + "],  ErrorMessage=[" + details.errorMessage() + "]";
+            String errMsg = sdkException.getMessage();
             switch (details.sdkHttpResponse().statusCode()) {
                 case HttpStatusCode.BAD_REQUEST:
                     //

--- a/src/test/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxyTest.java
+++ b/src/test/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxyTest.java
@@ -439,7 +439,7 @@ public class AmazonWebServicesClientProxyTest {
                 .initiate("client:createRespository", proxy.newProxy(() -> mock(ServiceClient.class)), model, context)
                 .translateToServiceRequest(m -> new CreateRequest.Builder().repoName(m.getRepoName()).build())
                 .makeServiceCall((r, c) -> {
-                    throw new BadRequestException(mock(AwsServiceException.Builder.class)) {
+                    throw new BadRequestException(new AwsServiceException(AwsServiceException.builder()) {
                         private static final long serialVersionUID = 1L;
 
                         @Override
@@ -447,10 +447,10 @@ public class AmazonWebServicesClientProxyTest {
                             return AwsErrorDetails.builder().errorCode("BadRequest").errorMessage("Bad Parameter in request")
                                 .sdkHttpResponse(sdkHttpResponse).build();
                         }
-                    };
+                    }.toBuilder());
                 }).done(o -> ProgressEvent.success(model, context));
         assertThat(result.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(result.getMessage()).contains("BadRequest");
+        assertThat(result.getMessage()).contains("Bad Parameter");
     }
 
     @Test
@@ -470,7 +470,7 @@ public class AmazonWebServicesClientProxyTest {
                 .initiate("client:createRespository", proxy.newProxy(() -> mock(ServiceClient.class)), model, context)
                 .translateToServiceRequest(m -> new CreateRequest.Builder().repoName(m.getRepoName()).build())
                 .makeServiceCall((r, c) -> {
-                    throw new NotFoundException(mock(AwsServiceException.Builder.class)) {
+                    throw new NotFoundException(new AwsServiceException(AwsServiceException.builder()) {
                         private static final long serialVersionUID = 1L;
 
                         @Override
@@ -478,10 +478,10 @@ public class AmazonWebServicesClientProxyTest {
                             return AwsErrorDetails.builder().errorCode("NotFound").errorMessage("Repo not existing")
                                 .sdkHttpResponse(sdkHttpResponse).build();
                         }
-                    };
+                    }.toBuilder());
                 }).done(o -> ProgressEvent.success(model, context));
         assertThat(result.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(result.getMessage()).contains("NotFound");
+        assertThat(result.getMessage()).contains("Repo not existing");
     }
 
     @Test
@@ -501,7 +501,7 @@ public class AmazonWebServicesClientProxyTest {
                 .initiate("client:createRespository", proxy.newProxy(() -> mock(ServiceClient.class)), model, context)
                 .translateToServiceRequest(m -> new CreateRequest.Builder().repoName(m.getRepoName()).build())
                 .makeServiceCall((r, c) -> {
-                    throw new AccessDenied(AwsServiceException.builder()) {
+                    throw new AccessDenied(new AwsServiceException(AwsServiceException.builder()) {
                         private static final long serialVersionUID = 1L;
 
                         @Override
@@ -509,11 +509,10 @@ public class AmazonWebServicesClientProxyTest {
                             return AwsErrorDetails.builder().errorCode("AccessDenied: 401").errorMessage("Token Invalid")
                                 .sdkHttpResponse(sdkHttpResponse).build();
                         }
-
-                    };
+                    }.toBuilder());
                 }).done(o -> ProgressEvent.success(model, context));
         assertThat(result.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(result.getMessage()).contains("AccessDenied");
+        assertThat(result.getMessage()).contains("Token Invalid");
     }
 
     @Test

--- a/src/test/java/software/amazon/cloudformation/proxy/End2EndCallChainTest.java
+++ b/src/test/java/software/amazon/cloudformation/proxy/End2EndCallChainTest.java
@@ -107,7 +107,7 @@ public class End2EndCallChainTest {
         //
         // Now reset expectation to fail with already exists
         //
-        final ExistsException exists = new ExistsException(mock(AwsServiceException.Builder.class)) {
+        final ExistsException exists = new ExistsException(new AwsServiceException(AwsServiceException.builder()) {
             private static final long serialVersionUID = 1L;
 
             @Override
@@ -115,7 +115,7 @@ public class End2EndCallChainTest {
                 return AwsErrorDetails.builder().errorCode("AlreadyExists").errorMessage("Repo already exists")
                     .sdkHttpResponse(sdkHttpResponse).build();
             }
-        };
+        }.toBuilder());
         when(serviceClient.createRepository(any(CreateRequest.class))).thenThrow(exists);
         StdCallbackContext newContext = new StdCallbackContext();
         event = proxy.initiate("client:createRepository", client, model, newContext)
@@ -124,7 +124,7 @@ public class End2EndCallChainTest {
             .done(r -> ProgressEvent.success(model, context));
 
         assertThat(event.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(event.getMessage()).contains("AlreadyExists");
+        assertThat(event.getMessage()).contains("Repo already exists");
     }
 
     private HandlerRequest<Model, StdCallbackContext> prepareRequest(Model model) throws Exception {
@@ -196,7 +196,7 @@ public class End2EndCallChainTest {
         final DescribeRequest describeRequest = new DescribeRequest.Builder().repoName(model.getRepoName()).overrideConfiguration(
             AwsRequestOverrideConfiguration.builder().credentialsProvider(StaticCredentialsProvider.create(MockCreds)).build())
             .build();
-        final NotFoundException notFound = new NotFoundException(mock(AwsServiceException.Builder.class)) {
+        final NotFoundException notFound = new NotFoundException(new AwsServiceException(AwsServiceException.builder()) {
             private static final long serialVersionUID = 1L;
 
             @Override
@@ -204,7 +204,7 @@ public class End2EndCallChainTest {
                 return AwsErrorDetails.builder().errorCode("NotFound").errorMessage("Repo not existing")
                     .sdkHttpResponse(sdkHttpResponse).build();
             }
-        };
+        }.toBuilder());
         when(client.describeRepository(eq(describeRequest))).thenThrow(notFound);
 
         final SdkHttpClient httpClient = mock(SdkHttpClient.class);
@@ -221,7 +221,7 @@ public class End2EndCallChainTest {
             });
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getMessage()).contains("NotFound");
+        assertThat(response.getMessage()).contains("Repo not existing");
     }
 
     @SuppressWarnings("unchecked")
@@ -299,7 +299,7 @@ public class End2EndCallChainTest {
         final SdkHttpResponse sdkHttpResponse = mock(SdkHttpResponse.class);
         when(sdkHttpResponse.statusCode()).thenReturn(500);
 
-        final ExistsException exists = new ExistsException(mock(AwsServiceException.Builder.class)) {
+        final ExistsException exists = new ExistsException(new AwsServiceException(AwsServiceException.builder()) {
             private static final long serialVersionUID = 1L;
 
             @Override
@@ -307,7 +307,7 @@ public class End2EndCallChainTest {
                 return AwsErrorDetails.builder().errorCode("AlreadyExists").errorMessage("Repo already exists")
                     .sdkHttpResponse(sdkHttpResponse).build();
             }
-        };
+        }.toBuilder());
         when(client.createRepository(eq(createRequest))).thenThrow(exists);
 
         final SdkHttpClient httpClient = mock(SdkHttpClient.class);
@@ -327,7 +327,7 @@ public class End2EndCallChainTest {
         assertThat(request.getRequestData()).isNotNull();
         Model responseModel = response.getResourceModel();
         assertThat(responseModel.getRepoName()).isEqualTo("repository");
-        assertThat(response.getMessage()).contains("AlreadyExists");
+        assertThat(response.getMessage()).contains("Repo already exists");
     }
 
     @Order(30)
@@ -469,7 +469,7 @@ public class End2EndCallChainTest {
         final DescribeRequest describeRequest = new DescribeRequest.Builder().repoName(model.getRepoName()).overrideConfiguration(
             AwsRequestOverrideConfiguration.builder().credentialsProvider(StaticCredentialsProvider.create(MockCreds)).build())
             .build();
-        final AccessDenied accessDenied = new AccessDenied(mock(AwsServiceException.Builder.class)) {
+        final AccessDenied accessDenied = new AccessDenied(new AwsServiceException(AwsServiceException.builder()) {
             private static final long serialVersionUID = 1L;
 
             @Override
@@ -478,7 +478,7 @@ public class End2EndCallChainTest {
                     .sdkHttpResponse(sdkHttpResponse).build();
             }
 
-        };
+        }.toBuilder());
         when(client.describeRepository(eq(describeRequest))).thenThrow(accessDenied);
 
         final SdkHttpClient httpClient = mock(SdkHttpClient.class);
@@ -495,7 +495,7 @@ public class End2EndCallChainTest {
             });
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getMessage()).contains("AccessDenied");
+        assertThat(response.getMessage()).contains("Token Invalid");
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current error message is built with Java class name, which is ideal comparing with standard SDK exception message. It also miss important information such as request ID etc.

Just use standard SDK exception message which includes important information as well as not expose internal java class as event message.

__Event Message Before:__

```
Exception=[class software.amazon.awssdk.services.kms.model.KmsException] ErrorCode=[AccessDeniedException],  ErrorMessage=[User: arn:aws:sts::1234567890:assumed-role/abcd is not authorized to perform: kms:UntagResource on resource: arn:aws:kms:eu-central-1:1234567890:key/10b977e9-da47-4c82-929f-c3c3506709d0]
```

__Event Message After:__

```
User: arn:aws:sts::1234567890:assumed-role/abcd is not authorized to perform: kms:UntagResource on resource: arn:aws:kms:eu-central-1:1234567890:key/10b977e9-da47-4c82-929f-c3c3506709d0 (Service: AWSKMS; Status Code: 400;  Request ID: c86b48d0-2820-4ff3-a1de-d52ed24f922c)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
