### PR TITLE
Removed account ID from metric namespace

### DIFF
--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -137,8 +137,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
     private void initialiseRuntime(final String resourceType,
                                    final Credentials providerCredentials,
                                    final String providerLogGroupName,
-                                   final Context context,
-                                   final String awsAccountId) {
+                                   final Context context) {
 
         this.loggerProxy = new LoggerProxy();
         this.metricsPublisherProxy = new MetricsPublisherProxy();
@@ -160,7 +159,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
 
             if (this.providerMetricsPublisher == null) {
                 this.providerMetricsPublisher = new MetricsPublisherImpl(this.providerCloudWatchProvider, this.loggerProxy,
-                                                                         awsAccountId, resourceType);
+                                                                         resourceType);
             }
             this.metricsPublisherProxy.addMetricsPublisher(this.providerMetricsPublisher);
             this.providerMetricsPublisher.refreshClient();
@@ -255,7 +254,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
 
         // initialise dependencies
         initialiseRuntime(request.getResourceType(), request.getRequestData().getProviderCredentials(),
-            request.getRequestData().getProviderLogGroupName(), context, request.getAwsAccountId());
+            request.getRequestData().getProviderLogGroupName(), context);
 
         // transform the request object to pass to caller
         ResourceHandlerRequest<ResourceT> resourceHandlerRequest = transform(request);

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
@@ -33,18 +33,15 @@ public class MetricsPublisherImpl extends MetricsPublisher {
     private final CloudWatchProvider cloudWatchProvider;
 
     private Logger loggerProxy;
-    private String providerAccountId;
 
     private CloudWatchClient cloudWatchClient;
 
     public MetricsPublisherImpl(final CloudWatchProvider cloudWatchProvider,
                                 final Logger loggerProxy,
-                                final String providerAccountId,
                                 final String resourceTypeName) {
         super(resourceTypeName);
         this.cloudWatchProvider = cloudWatchProvider;
         this.loggerProxy = loggerProxy;
-        this.providerAccountId = providerAccountId;
     }
 
     public void refreshClient() {
@@ -115,8 +112,7 @@ public class MetricsPublisherImpl extends MetricsPublisher {
             .timestamp(timestamp).build();
 
         PutMetricDataRequest putMetricDataRequest = PutMetricDataRequest.builder()
-            .namespace(String.format("%s/%s/%s", Metric.METRIC_NAMESPACE_ROOT, providerAccountId, resourceNamespace))
-            .metricData(metricDatum).build();
+            .namespace(String.format("%s/%s", Metric.METRIC_NAMESPACE_ROOT, resourceNamespace)).metricData(metricDatum).build();
 
         try {
             this.cloudWatchClient.putMetricData(putMetricDataRequest);

--- a/src/test/java/software/amazon/cloudformation/metrics/MetricsPublisherImplTest.java
+++ b/src/test/java/software/amazon/cloudformation/metrics/MetricsPublisherImplTest.java
@@ -51,7 +51,6 @@ public class MetricsPublisherImplTest {
     @Mock
     private CloudWatchClient providerCloudWatchClient;
 
-    private String awsAccountId = "77384178834";
     private final String resourceTypeName = "AWS::Test::TestModel";
 
     @BeforeEach
@@ -70,7 +69,7 @@ public class MetricsPublisherImplTest {
     @Test
     public void testPublishDurationMetric() {
         final MetricsPublisherImpl providerMetricsPublisher = new MetricsPublisherImpl(providerCloudWatchProvider, loggerProxy,
-                                                                                       awsAccountId, resourceTypeName);
+                                                                                       resourceTypeName);
         providerMetricsPublisher.refreshClient();
 
         final Instant instant = Instant.parse("2019-06-04T17:50:00Z");
@@ -80,8 +79,7 @@ public class MetricsPublisherImplTest {
         verify(providerCloudWatchClient).putMetricData(argument1.capture());
 
         final PutMetricDataRequest request = argument1.getValue();
-        assertThat(request.namespace())
-            .isEqualTo(String.format("%s/%s/%s", "AWS/CloudFormation", awsAccountId, "AWS/Test/TestModel"));
+        assertThat(request.namespace()).isEqualTo(String.format("%s/%s", "AWS/CloudFormation", "AWS/Test/TestModel"));
 
         assertThat(request.metricData()).hasSize(1);
         final MetricDatum metricDatum = request.metricData().get(0);
@@ -96,7 +94,7 @@ public class MetricsPublisherImplTest {
     @Test
     public void testPublishExceptionMetric() {
         final MetricsPublisherImpl providerMetricsPublisher = new MetricsPublisherImpl(providerCloudWatchProvider, loggerProxy,
-                                                                                       awsAccountId, resourceTypeName);
+                                                                                       resourceTypeName);
         providerMetricsPublisher.refreshClient();
 
         final Instant instant = Instant.parse("2019-06-03T17:50:00Z");
@@ -107,8 +105,7 @@ public class MetricsPublisherImplTest {
         verify(providerCloudWatchClient).putMetricData(argument1.capture());
 
         final PutMetricDataRequest request = argument1.getValue();
-        assertThat(request.namespace())
-            .isEqualTo(String.format("%s/%s/%s", "AWS/CloudFormation", awsAccountId, "AWS/Test/TestModel"));
+        assertThat(request.namespace()).isEqualTo(String.format("%s/%s", "AWS/CloudFormation", "AWS/Test/TestModel"));
 
         assertThat(request.metricData()).hasSize(1);
         final MetricDatum metricDatum = request.metricData().get(0);
@@ -125,7 +122,7 @@ public class MetricsPublisherImplTest {
     @Test
     public void testPublishInvocationMetric() {
         final MetricsPublisherImpl providerMetricsPublisher = new MetricsPublisherImpl(providerCloudWatchProvider, loggerProxy,
-                                                                                       awsAccountId, resourceTypeName);
+                                                                                       resourceTypeName);
         providerMetricsPublisher.refreshClient();
 
         final Instant instant = Instant.parse("2019-06-04T17:50:00Z");
@@ -135,8 +132,7 @@ public class MetricsPublisherImplTest {
         verify(providerCloudWatchClient).putMetricData(argument1.capture());
 
         final PutMetricDataRequest request = argument1.getValue();
-        assertThat(request.namespace())
-            .isEqualTo(String.format("%s/%s/%s", "AWS/CloudFormation", awsAccountId, "AWS/Test/TestModel"));
+        assertThat(request.namespace()).isEqualTo(String.format("%s/%s", "AWS/CloudFormation", "AWS/Test/TestModel"));
 
         assertThat(request.metricData()).hasSize(1);
         final MetricDatum metricDatum = request.metricData().get(0);


### PR DESCRIPTION
The removed account ID is the customer account ID instead of the provider account ID. This means that for public types, a new metric namespace would be created each time we need to emit metrics. The main issue with this is that the internal and logging failure alarms will not work properly and service teams may not be notified of issues.

Go plugin PR: https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/pull/151
Python plugin PR: https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/pull/108

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
