### PR TITLE
Not fail if java plugin doesn't in pom.xml

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -399,23 +399,33 @@ class JavaLanguagePlugin(LanguagePlugin):
                 )
             project.overwrite(path, contents)
 
-        # Update settings
-        java_plugin_dependency_version = self._get_java_plugin_dependency_version(
-            project
-        )
-        if java_plugin_dependency_version < MINIMUM_JAVA_DEPENDENCY_VERSION:
-            raise JavaPluginVersionNotSupportedError(
-                "'aws-cloudformation-rpdk-java-plugin' {} is no longer supported."
-                "Please update it in pom.xml to version {} or above.".format(
-                    java_plugin_dependency_version, MINIMUM_JAVA_DEPENDENCY_VERSION
-                )
+        self._update_settings(project)
+
+        LOG.debug("Generate complete")
+
+    def _update_settings(self, project):
+        try:
+            java_plugin_dependency_version = self._get_java_plugin_dependency_version(
+                project
             )
+            if java_plugin_dependency_version < MINIMUM_JAVA_DEPENDENCY_VERSION:
+                raise JavaPluginVersionNotSupportedError(
+                    "'aws-cloudformation-rpdk-java-plugin' {} is no longer supported."
+                    "Please update it in pom.xml to version {} or above.".format(
+                        java_plugin_dependency_version, MINIMUM_JAVA_DEPENDENCY_VERSION
+                    )
+                )
+        except JavaPluginNotFoundError:
+            LOG.info(
+                "Please make sure to have 'aws-cloudformation-rpdk-java-plugin' "
+                "to version %s or above.",
+                MINIMUM_JAVA_DEPENDENCY_VERSION,
+            )
+
         protocol_version = project.settings.get(PROTOCOL_VERSION_SETTING)
         if protocol_version != DEFAULT_PROTOCOL_VERSION:
             project.settings[PROTOCOL_VERSION_SETTING] = DEFAULT_PROTOCOL_VERSION
             project.write_settings()
-
-        LOG.debug("Generate complete")
 
     @staticmethod
     def _find_jar(project):

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -169,6 +169,12 @@ def test__get_plugin_version_not_found(project):
         project._plugin._get_java_plugin_dependency_version(project)
 
 
+def test_generate_without_java_plugin_in_pom_should_not_fail(project):
+    make_pom_xml_without_plugin(project)
+    project.generate()
+    assert project.settings["protocolVersion"] == "2.0.0"
+
+
 def test__get_plugin_version_invalid_pom(project):
     pom = open(project.root / "pom.xml", "w")
     pom.write("invalid pom")


### PR DESCRIPTION
*Issue #, if available:* #282 

*Description of changes:*

As described in #282,  the java plugin could be configured somewhere else other than the pom.xml under the resource handler directory.   

The tool was trying to help the runtime dependency compatibility check, but it should not have assumption on how to build the package as there are various ways to build the package.

This PR will loose the java plugin version check in pom.xml. If the java plugin dependency doesn't find, don't fail the `generate`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
