### PR TITLE
Added writeOnlyProperties redaction to testEntrypoint

### DIFF
--- a/python/rpdk/java/templates/generate/HandlerWrapper.java
+++ b/python/rpdk/java/templates/generate/HandlerWrapper.java
@@ -106,9 +106,7 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             e.printStackTrace();
             response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InternalFailure);
         } finally {
-            final String output = this.serializer.serialize(response);
-            outputStream.write(output.getBytes(Charset.forName("UTF-8")));
-            outputStream.close();
+            writeResponse(outputStream, response);
         }
     }
 


### PR DESCRIPTION
This fix allows the contract tests to correctly assert on writeOnlyProperties being removed from the model.

*Issue #, if available:* N/A

*Description of changes:* Contract tests were reporting false negatives for the redaction of `writeOnlyProperties`. Minor refactoring so that the `testEntrypoint` also sanitizes the model by default.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
