### PR TITLE
additional cw-metrics

### DIFF
--- a/src/main/java/software/amazon/cloudformation/metrics/Metric.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/Metric.java
@@ -18,6 +18,8 @@ public class Metric {
 
     public static final String METRIC_NAMESPACE_ROOT = "AWS/CloudFormation";
     public static final String METRIC_NAME_HANDLER_EXCEPTION = "HandlerException";
+    public static final String METRIC_NAME_HANDLER_EXCEPTION_BY_ERROR_CODE = "HandlerExceptionByErrorCode";
+    public static final String METRIC_NAME_HANDLER_EXCEPTION_BY_EXCEPTION_COUNT = "HandlerExceptionByExceptionCount";
     public static final String METRIC_NAME_HANDLER_DURATION = "HandlerInvocationDuration";
     public static final String METRIC_NAME_HANDLER_INVOCATION_COUNT = "HandlerInvocationCount";
 

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
@@ -42,6 +42,13 @@ public abstract class MetricsPublisher {
                                        final HandlerErrorCode handlerErrorCode) {
     }
 
+    public void
+        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
+    }
+
+    public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {
+    }
+
     public void publishInvocationMetric(final Instant timestamp, final Action action) {
     }
 

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
@@ -42,8 +42,10 @@ public abstract class MetricsPublisher {
                                        final HandlerErrorCode handlerErrorCode) {
     }
 
-    public void
-        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
+    public void publishExceptionByErrorCodeMetric(final Instant timestamp,
+                                                  final Action action,
+                                                  final HandlerErrorCode handlerErrorCode,
+                                                  final boolean thrown) {
     }
 
     public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
@@ -67,6 +67,24 @@ public class MetricsPublisherImpl extends MetricsPublisher {
     }
 
     @Override
+    public void
+        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(Metric.DIMENSION_KEY_ACTION_TYPE, action == null ? "NO_ACTION" : action.name());
+        dimensions.put(Metric.DIMENSION_KEY_HANDLER_ERROR_CODE, handlerErrorCode.name());
+
+        publishMetric(Metric.METRIC_NAME_HANDLER_EXCEPTION_BY_ERROR_CODE, dimensions, StandardUnit.COUNT, 1.0, timestamp);
+    }
+
+    public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(Metric.DIMENSION_KEY_ACTION_TYPE, action == null ? "NO_ACTION" : action.name());
+
+        publishMetric(Metric.METRIC_NAME_HANDLER_EXCEPTION_BY_EXCEPTION_COUNT, dimensions, StandardUnit.COUNT, thrown ? 1.0 : 0.0,
+            timestamp);
+    }
+
+    @Override
     public void publishProviderLogDeliveryExceptionMetric(final Instant timestamp, final Throwable e) {
         Map<String, String> dimensions = new HashMap<>();
         dimensions.put(Metric.DIMENSION_KEY_ACTION_TYPE, "ProviderLogDelivery");

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisherImpl.java
@@ -67,13 +67,16 @@ public class MetricsPublisherImpl extends MetricsPublisher {
     }
 
     @Override
-    public void
-        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
+    public void publishExceptionByErrorCodeMetric(final Instant timestamp,
+                                                  final Action action,
+                                                  final HandlerErrorCode handlerErrorCode,
+                                                  final boolean thrown) {
         Map<String, String> dimensions = new HashMap<>();
         dimensions.put(Metric.DIMENSION_KEY_ACTION_TYPE, action == null ? "NO_ACTION" : action.name());
         dimensions.put(Metric.DIMENSION_KEY_HANDLER_ERROR_CODE, handlerErrorCode.name());
 
-        publishMetric(Metric.METRIC_NAME_HANDLER_EXCEPTION_BY_ERROR_CODE, dimensions, StandardUnit.COUNT, 1.0, timestamp);
+        publishMetric(Metric.METRIC_NAME_HANDLER_EXCEPTION_BY_ERROR_CODE, dimensions, StandardUnit.COUNT, thrown ? 1.0 : 0.0,
+            timestamp);
     }
 
     public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {

--- a/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
@@ -35,6 +35,17 @@ public class MetricsPublisherProxy {
             .forEach(metricsPublisher -> metricsPublisher.publishExceptionMetric(timestamp, action, e, handlerErrorCode));
     }
 
+    public void
+        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
+        metricsPublishers.stream()
+            .forEach(metricsPublisher -> metricsPublisher.publishExceptionByErrorCodeMetric(timestamp, action, handlerErrorCode));
+    }
+
+    public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {
+        metricsPublishers.stream()
+            .forEach(metricsPublisher -> metricsPublisher.publishExceptionCountMetric(timestamp, action, thrown));
+    }
+
     public void publishInvocationMetric(final Instant timestamp, final Action action) {
         metricsPublishers.stream().forEach(metricsPublisher -> metricsPublisher.publishInvocationMetric(timestamp, action));
     }

--- a/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
@@ -35,10 +35,12 @@ public class MetricsPublisherProxy {
             .forEach(metricsPublisher -> metricsPublisher.publishExceptionMetric(timestamp, action, e, handlerErrorCode));
     }
 
-    public void
-        publishExceptionByErrorCodeMetric(final Instant timestamp, final Action action, final HandlerErrorCode handlerErrorCode) {
-        metricsPublishers.stream()
-            .forEach(metricsPublisher -> metricsPublisher.publishExceptionByErrorCodeMetric(timestamp, action, handlerErrorCode));
+    public void publishExceptionByErrorCodeMetric(final Instant timestamp,
+                                                  final Action action,
+                                                  final HandlerErrorCode handlerErrorCode,
+                                                  final boolean thrown) {
+        metricsPublishers.stream().forEach(
+            metricsPublisher -> metricsPublisher.publishExceptionByErrorCodeMetric(timestamp, action, handlerErrorCode, thrown));
     }
 
     public void publishExceptionCountMetric(final Instant timestamp, final Action action, final boolean thrown) {

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -811,6 +811,12 @@ public class LambdaWrapperTest {
             // verify initialiseRuntime was called and initialised dependencies
             verifyInitialiseRuntime();
 
+            verify(providerMetricsPublisher).publishExceptionByErrorCodeMetric(any(Instant.class), any(Action.class),
+                any(HandlerErrorCode.class), any(Boolean.class));
+
+            verify(providerMetricsPublisher).publishExceptionCountMetric(any(Instant.class), any(Action.class),
+                any(Boolean.class));
+
             // no further calls to metrics publisher should occur
             verifyNoMoreInteractions(providerMetricsPublisher);
 

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -161,12 +161,12 @@ public class LambdaWrapperTest {
             verify(providerMetricsPublisher).publishExceptionMetric(any(Instant.class), any(), any(TerminalException.class),
                 any(HandlerErrorCode.class));
             verify(providerMetricsPublisher).publishExceptionByErrorCodeMetric(any(Instant.class), any(),
-                any(HandlerErrorCode.class));
+                any(HandlerErrorCode.class), eq(Boolean.TRUE));
             verify(providerMetricsPublisher).publishExceptionCountMetric(any(Instant.class), any(), any(Boolean.class));
 
             // all metrics should be published even on terminal failure
-            verify(providerMetricsPublisher, times(1)).publishInvocationMetric(any(Instant.class), eq(action));
-            verify(providerMetricsPublisher, times(1)).publishDurationMetric(any(Instant.class), eq(action), anyLong());
+            verify(providerMetricsPublisher).publishInvocationMetric(any(Instant.class), eq(action));
+            verify(providerMetricsPublisher).publishDurationMetric(any(Instant.class), eq(action), anyLong());
 
             // verify that model validation occurred for CREATE/UPDATE/DELETE
             if (action == Action.CREATE || action == Action.UPDATE || action == Action.DELETE) {
@@ -402,6 +402,8 @@ public class LambdaWrapperTest {
                 // verify output response
                 verifyHandlerResponse(out, ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.IN_PROGRESS)
                     .resourceModel(TestModel.builder().property1("abc").property2(123).build()).build());
+                verify(providerMetricsPublisher, atLeastOnce()).publishExceptionByErrorCodeMetric(any(Instant.class), eq(action),
+                    any(), eq(Boolean.FALSE));
                 verify(providerMetricsPublisher).publishExceptionCountMetric(any(Instant.class), eq(action), eq(Boolean.FALSE));
             } else {
                 verifyHandlerResponse(out,
@@ -411,7 +413,7 @@ public class LambdaWrapperTest {
                 verify(providerMetricsPublisher).publishExceptionMetric(any(Instant.class), eq(action),
                     any(TerminalException.class), eq(HandlerErrorCode.InternalFailure));
                 verify(providerMetricsPublisher).publishExceptionByErrorCodeMetric(any(Instant.class), eq(action),
-                    eq(HandlerErrorCode.InternalFailure));
+                    eq(HandlerErrorCode.InternalFailure), eq(Boolean.TRUE));
                 verify(providerMetricsPublisher).publishExceptionCountMetric(any(Instant.class), eq(action), eq(Boolean.TRUE));
             }
 
@@ -456,6 +458,8 @@ public class LambdaWrapperTest {
             // all metrics should be published, once for a single invocation
             verify(providerMetricsPublisher).publishInvocationMetric(any(Instant.class), eq(action));
             verify(providerMetricsPublisher).publishDurationMetric(any(Instant.class), eq(action), anyLong());
+            verify(providerMetricsPublisher, atLeastOnce()).publishExceptionByErrorCodeMetric(any(Instant.class), eq(action),
+                any(), eq(Boolean.FALSE));
             verify(providerMetricsPublisher).publishExceptionCountMetric(any(Instant.class), eq(action), eq(Boolean.FALSE));
 
             // validation failure metric should not be published


### PR DESCRIPTION
*Issue #, if available:* #297 

*Description of changes:*

Added some extra metrics so to create cw alarms upon. 

**Metric No. 1**
```
Namespace: under resource type namespace
Metric name: "HandlerException"
Dimensions: Action, HandlerErrorCode, ResourceType 
```

**Metric No. 2** - not added: the reason being is that operation status for uncaught exceptions is always `FAILED`, so this metrics seems to be redundant; we have enough of the exact same information in other dimensions;
```
Namespace:  <does not really matter>
Metric name: "HandlerException"
Dimensions: Action, OperationStatus, ResourceType # with OperationStatus in software.amazon.cloudformation.proxy.OperationStatus.values()
```

**Metric No. 3**
```
Namespace:  under resource type namespace
Metric name: "HandlerException"
Dimensions: Action, ResourceType
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
