### PR TITLE
Add getPreviousResourceTags method 

### DIFF
--- a/python/rpdk/java/templates/generate/HandlerWrapper.java
+++ b/python/rpdk/java/templates/generate/HandlerWrapper.java
@@ -132,7 +132,6 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             .desiredResourceState(requestData.getResourceProperties())
             .previousResourceState(requestData.getPreviousResourceProperties())
             .desiredResourceTags(getDesiredResourceTags(request))
-            .previousResourceTags(getPreviousResourceTags(request))
             .systemTags(request.getRequestData().getSystemTags())
             .awsAccountId(request.getAwsAccountId())
             .logicalResourceIdentifier(request.getRequestData().getLogicalResourceId())

--- a/python/rpdk/java/templates/generate/HandlerWrapper.java
+++ b/python/rpdk/java/templates/generate/HandlerWrapper.java
@@ -132,6 +132,7 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             .desiredResourceState(requestData.getResourceProperties())
             .previousResourceState(requestData.getPreviousResourceProperties())
             .desiredResourceTags(getDesiredResourceTags(request))
+            .previousResourceTags(getPreviousResourceTags(request))
             .systemTags(request.getRequestData().getSystemTags())
             .awsAccountId(request.getAwsAccountId())
             .logicalResourceIdentifier(request.getRequestData().getLogicalResourceId())

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -259,7 +259,9 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         // transform the request object to pass to caller
         ResourceHandlerRequest<ResourceT> resourceHandlerRequest = transform(request);
 
-        resourceHandlerRequest.setPreviousResourceTags(getPreviousResourceTags(request));
+        if(resourceHandlerRequest != null) {
+            resourceHandlerRequest.setPreviousResourceTags(getPreviousResourceTags(request));
+        }
 
         this.metricsPublisherProxy.publishInvocationMetric(Instant.now(), request.getAction());
 

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -259,6 +259,8 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         // transform the request object to pass to caller
         ResourceHandlerRequest<ResourceT> resourceHandlerRequest = transform(request);
 
+        resourceHandlerRequest.setPreviousResourceTags(getPreviousResourceTags(request));
+
         this.metricsPublisherProxy.publishInvocationMetric(Instant.now(), request.getAction());
 
         // for CUD actions, validate incoming model - any error is a terminal failure on

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -502,7 +502,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
     /**
      * Combines the tags supplied by the caller (e.g; CloudFormation) into a single
      * Map which represents the desired final set of tags to be applied to this
-     * resource.
+     * resource. User-defined tags
      *
      * @param request The request object contains the new set of tags to be applied
      *            at a Stack level. These will be overridden with any resource-level
@@ -524,7 +524,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
     /**
      * Combines the previous tags supplied by the caller (e.g; CloudFormation) into a single
      * Map which represents the desired final set of tags that were applied to this
-     * resource in the previous state. User-defined tags
+     * resource in the previous state.
      *
      * @param request The request object contains the new set of tags to be applied
      *            at a Stack level. These will be overridden with any resource-level

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -502,7 +502,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
     /**
      * Combines the tags supplied by the caller (e.g; CloudFormation) into a single
      * Map which represents the desired final set of tags to be applied to this
-     * resource. User-defined tags
+     * resource.
      *
      * @param request The request object contains the new set of tags to be applied
      *            at a Stack level. These will be overridden with any resource-level
@@ -519,6 +519,29 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         }
 
         return desiredResourceTags;
+    }
+
+    /**
+     * Combines the previous tags supplied by the caller (e.g; CloudFormation) into a single
+     * Map which represents the desired final set of tags that were applied to this
+     * resource in the previous state. User-defined tags
+     *
+     * @param request The request object contains the new set of tags to be applied
+     *            at a Stack level. These will be overridden with any resource-level
+     *            tags which are specified as a direct resource property.
+     * @return a Map of Tag names to Tag values
+     */
+    @VisibleForTesting
+    protected Map<String, String> getPreviousResourceTags(final HandlerRequest<ResourceT, CallbackT> request) {
+        Map<String, String> previousResourceTags = new HashMap<>();
+
+        if (request != null && request.getRequestData() != null) {
+            replaceInMap(previousResourceTags, request.getRequestData().getPreviousStackTags());
+            replaceInMap(previousResourceTags,
+                provideResourceDefinedTags(request.getRequestData().getPreviousResourceProperties()));
+        }
+
+        return previousResourceTags;
     }
 
     private void replaceInMap(final Map<String, String> targetMap, final Map<String, String> sourceMap) {

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -537,8 +537,10 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
 
         if (request != null && request.getRequestData() != null) {
             replaceInMap(previousResourceTags, request.getRequestData().getPreviousStackTags());
-            replaceInMap(previousResourceTags,
-                provideResourceDefinedTags(request.getRequestData().getPreviousResourceProperties()));
+            if (request.getRequestData().getPreviousResourceProperties() != null) {
+                replaceInMap(previousResourceTags,
+                    provideResourceDefinedTags(request.getRequestData().getPreviousResourceProperties()));
+            }
         }
 
         return previousResourceTags;

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -259,7 +259,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
         // transform the request object to pass to caller
         ResourceHandlerRequest<ResourceT> resourceHandlerRequest = transform(request);
 
-        if(resourceHandlerRequest != null) {
+        if (resourceHandlerRequest != null) {
             resourceHandlerRequest.setPreviousResourceTags(getPreviousResourceTags(request));
         }
 
@@ -526,9 +526,9 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
     }
 
     /**
-     * Combines the previous tags supplied by the caller (e.g; CloudFormation) into a single
-     * Map which represents the desired final set of tags that were applied to this
-     * resource in the previous state.
+     * Combines the previous tags supplied by the caller (e.g; CloudFormation) into
+     * a single Map which represents the desired final set of tags that were applied
+     * to this resource in the previous state.
      *
      * @param request The request object contains the new set of tags to be applied
      *            at a Stack level. These will be overridden with any resource-level

--- a/src/main/java/software/amazon/cloudformation/proxy/RequestData.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/RequestData.java
@@ -29,4 +29,5 @@ public class RequestData<ResourceT> {
     private ResourceT previousResourceProperties;
     private Map<String, String> systemTags;
     private Map<String, String> stackTags;
+    private Map<String, String> previousStackTags;
 }

--- a/src/main/java/software/amazon/cloudformation/proxy/ResourceHandlerRequest.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/ResourceHandlerRequest.java
@@ -36,6 +36,7 @@ public class ResourceHandlerRequest<T> {
     private T desiredResourceState;
     private T previousResourceState;
     private Map<String, String> desiredResourceTags;
+    private Map<String, String> previousResourceTags;
     private Map<String, String> systemTags;
     private String awsAccountId;
     private String awsPartition;

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -956,4 +956,47 @@ public class LambdaWrapperTest {
         assertThat(tags.size()).isEqualTo(1);
         assertThat(tags.get("Tag1")).isEqualTo("Value2");
     }
+
+    @Test
+    public void getPreviousResourceTags_oneStackTagAndOneResourceTag() {
+        final Map<String, String> stackTags = new HashMap<>();
+        stackTags.put("Tag1", "Value1");
+
+        final Map<String, String> resourceTags = new HashMap<>();
+        resourceTags.put("Tag2", "Value2");
+        final TestModel model = TestModel.builder().tags(resourceTags).build();
+
+        final HandlerRequest<TestModel, TestContext> request = new HandlerRequest<>();
+        final RequestData<TestModel> requestData = new RequestData<>();
+        requestData.setPreviousResourceProperties(model);
+        requestData.setPreviousStackTags(stackTags);
+        request.setRequestData(requestData);
+
+        final Map<String, String> tags = wrapper.getPreviousResourceTags(request);
+        assertThat(tags).isNotNull();
+        assertThat(tags.size()).isEqualTo(2);
+        assertThat(tags.get("Tag1")).isEqualTo("Value1");
+        assertThat(tags.get("Tag2")).isEqualTo("Value2");
+    }
+
+    @Test
+    public void getPreviousResourceTags_resourceTagOverridesStackTag() {
+        final Map<String, String> stackTags = new HashMap<>();
+        stackTags.put("Tag1", "Value1");
+
+        final Map<String, String> resourceTags = new HashMap<>();
+        resourceTags.put("Tag1", "Value2");
+        final TestModel model = TestModel.builder().tags(resourceTags).build();
+
+        final HandlerRequest<TestModel, TestContext> request = new HandlerRequest<>();
+        final RequestData<TestModel> requestData = new RequestData<>();
+        requestData.setPreviousResourceProperties(model);
+        requestData.setPreviousStackTags(stackTags);
+        request.setRequestData(requestData);
+
+        final Map<String, String> tags = wrapper.getPreviousResourceTags(request);
+        assertThat(tags).isNotNull();
+        assertThat(tags.size()).isEqualTo(1);
+        assertThat(tags.get("Tag1")).isEqualTo("Value2");
+    }
 }


### PR DESCRIPTION
Issue #, if available: #292
    
Description of changes: This change adds getPreviousResourceTags method which returns previous tags that were applied to a resource. The tags come from previousStackTags and previousResourceDefinedTags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
