### PR TITLE
Handle AwsServiceExceptions thrown by handlers

### DIFF
--- a/python/rpdk/java/templates/generate/HandlerWrapper.java
+++ b/python/rpdk/java/templates/generate/HandlerWrapper.java
@@ -2,6 +2,7 @@
 package {{ package_name }};
 
 import com.amazonaws.AmazonServiceException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.cloudformation.Action;

--- a/python/rpdk/java/templates/generate/HandlerWrapper.java
+++ b/python/rpdk/java/templates/generate/HandlerWrapper.java
@@ -100,7 +100,7 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}, Callbac
             response = invokeHandler(proxy, payload.getRequest(), payload.getAction(), payload.getCallbackContext());
         } catch (final BaseHandlerException e) {
             response = ProgressEvent.defaultFailureHandler(e, e.getErrorCode());
-        } catch (final AmazonServiceException e) {
+        } catch (final AmazonServiceException | AwsServiceException e) {
             response = ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.GeneralServiceException);
         } catch (final Throwable e) {
             e.printStackTrace();

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -39,6 +39,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.utils.StringUtils;
@@ -361,7 +362,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
             publishExceptionMetric(request.getAction(), e, e.getErrorCode());
             logUnhandledError(e.getMessage(), request, e);
             return ProgressEvent.defaultFailureHandler(e, e.getErrorCode());
-        } catch (final AmazonServiceException e) {
+        } catch (final AmazonServiceException | AwsServiceException e) {
             publishExceptionMetric(request.getAction(), e, HandlerErrorCode.GeneralServiceException);
             logUnhandledError("A downstream service error occurred", request, e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.GeneralServiceException);


### PR DESCRIPTION
*Description of changes:* We should handle AwsServiceExceptions to lessen the need for providers to write boiler-plate error-handling code

Tested with unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
