### PR TITLE
added invalid request on invalid payload deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.89</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.88</minimum>
+                                            <minimum>0.89</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/LambdaWrapper.java
@@ -210,7 +210,7 @@ public abstract class LambdaWrapper<ResourceT, CallbackT> implements RequestStre
                 this.validator.validateObject(rawModelObject, resourceSchemaJSONObject);
 
                 handlerResponse = ProgressEvent.defaultFailureHandler(
-                    new CfnInvalidRequestException("Model validation failed caused by invalid input provided", e),
+                    new CfnInvalidRequestException("Resource properties validation failed with invalid configuration", e),
                     HandlerErrorCode.InvalidRequest);
             }
 

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -216,7 +216,7 @@ public class LambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out, ProgressEvent.<TestModel, TestContext>builder().errorCode(HandlerErrorCode.InvalidRequest)
-                .status(OperationStatus.FAILED).message("Model validation failed caused by invalid input provided").build());
+                .status(OperationStatus.FAILED).message("Resource properties validation failed with invalid configuration").build());
         }
     }
 

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -216,7 +216,7 @@ public class LambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out, ProgressEvent.<TestModel, TestContext>builder().errorCode(HandlerErrorCode.InvalidRequest)
-                .status(OperationStatus.FAILED).build());
+                .status(OperationStatus.FAILED).message("Model validation failed caused by invalid input provided").build());
         }
     }
 
@@ -362,7 +362,7 @@ public class LambdaWrapperTest {
         }
     }
 
-    // @Test
+    @Test
     public void invokeHandler_DependenciesInitialised_CompleteSynchronously_returnsSuccess() throws IOException {
         final WrapperOverride wrapper = new WrapperOverride();
         final TestModel model = new TestModel();

--- a/src/test/java/software/amazon/cloudformation/data/create.request.with-extraneous-model-object.json
+++ b/src/test/java/software/amazon/cloudformation/data/create.request.with-extraneous-model-object.json
@@ -1,43 +1,43 @@
 {
-  "awsAccountId": "123456789012",
-  "bearerToken": "123456",
-  "region": "us-east-1",
-  "action": "CREATE",
-  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
-  "resourceType": "AWS::Test::TestModel",
-  "resourceTypeVersion": "1.0",
-  "requestContext": {},
-  "requestData": {
-    "callerCredentials": {
-      "accessKeyId": "IASAYK835GAIFHAHEI23",
-      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
-      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
-    },
-    "providerCredentials": {
-      "accessKeyId": "HDI0745692Y45IUTYR78",
-      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
-      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
-    },
-    "providerLogGroupName": "providerLoggingGroupName",
-    "logicalResourceId": "myBucket",
-    "resourceProperties": {
-      "property1": "abc",
-      "property2": 123,
-      "fieldCausesValidationError": {
-        "fieldCausesValidationErrorProperty1": {
-          "fieldCausesValidationErrorProperty2": "DONOTIGNORE"
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestContext": {},
+    "requestData": {
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "providerCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "providerLogGroupName": "providerLoggingGroupName",
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {
+            "property1": "abc",
+            "property2": 123,
+            "property3": {
+                "subProperty": {
+                    "propertyArray": "singleValue"
+                }
+            }
+        },
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
         }
-      }
     },
-    "systemTags": {
-      "aws:cloudformation:stack-id": "SampleStack"
-    },
-    "stackTags": {
-      "tag1": "abc"
-    },
-    "previousStackTags": {
-      "tag1": "def"
-    }
-  },
-  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
 }

--- a/src/test/java/software/amazon/cloudformation/data/create.request.with-extraneous-model-object.json
+++ b/src/test/java/software/amazon/cloudformation/data/create.request.with-extraneous-model-object.json
@@ -1,0 +1,43 @@
+{
+  "awsAccountId": "123456789012",
+  "bearerToken": "123456",
+  "region": "us-east-1",
+  "action": "CREATE",
+  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+  "resourceType": "AWS::Test::TestModel",
+  "resourceTypeVersion": "1.0",
+  "requestContext": {},
+  "requestData": {
+    "callerCredentials": {
+      "accessKeyId": "IASAYK835GAIFHAHEI23",
+      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+    },
+    "providerCredentials": {
+      "accessKeyId": "HDI0745692Y45IUTYR78",
+      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+    },
+    "providerLogGroupName": "providerLoggingGroupName",
+    "logicalResourceId": "myBucket",
+    "resourceProperties": {
+      "property1": "abc",
+      "property2": 123,
+      "fieldCausesValidationError": {
+        "fieldCausesValidationErrorProperty1": {
+          "fieldCausesValidationErrorProperty2": "DONOTIGNORE"
+        }
+      }
+    },
+    "systemTags": {
+      "aws:cloudformation:stack-id": "SampleStack"
+    },
+    "stackTags": {
+      "tag1": "abc"
+    },
+    "previousStackTags": {
+      "tag1": "def"
+    }
+  },
+  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/src/test/resources/software/amazon/cloudformation/wrapper-override.json
+++ b/src/test/resources/software/amazon/cloudformation/wrapper-override.json
@@ -1,12 +1,33 @@
 {
     "typeName": "Test::Resource::Type",
     "description": "Description",
+    "definitions": {
+        "subProperty": {
+            "type": "object",
+            "properties": {
+                "propertyArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
     "properties": {
         "property1": {
             "type": "string"
         },
         "property2": {
             "type": "integer"
+        },
+        "property3": {
+            "type": "object",
+            "properties": {
+                "subProperty": {
+                    "$ref": "#/definitions/subProperty"
+                }
+            }
         }
     },
     "additionalProperties": false,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, when we hit `MismatchedInputException` on payload deserialization we get `InternalFailure`, which is not surfacing real issue to the customer; Alternatively we could put model validation upfront but then we will have strict validation on stringification; this is a good alternative as customers can see that the input is actually invalid

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
