### PR TITLE
Use CLI arguments in travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - DIR=$(mktemp -d)
         - cd "$DIR"
         - ls -la
-        - printf "AWS::Foo::Bar\n\n1" | cfn init -vv
+        - cfn init -vv -t AWS::Foo::Bar
         - mvn verify
         - ls -la
     - stage: "integ guided"
@@ -53,6 +53,6 @@ jobs:
         - DIR=$(mktemp -d)
         - cd "$DIR"
         - ls -la
-        - printf "AWS::Foo::Bar\n\n2" | cfn init -vv
+        - cfn init -vv -t AWS::Foo::Bar
         - mvn verify
         - ls -la


### PR DESCRIPTION
*Description of changes:*
Use CLI arguments for more clarity to run `cfn init` in the travis buil.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
