### PR TITLE
Long addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip3 install cloudformation-cli-java-plugin
 
 Refer to the [CloudFormation CLI User Guide](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html) for the [CloudFormation CLI](https://github.com/aws-cloudformation/cloudformation-cli) for usage instructions.
 
-###Alternate Type Formats
+### Alternate Type Formats
 The `format` keyword can be specified on primitive types defined in a resource provider's schema to allow the CloudFormation CLI Java Plugin to generate more than the defaults for primitive types. Consult the table below for what formats are available and defaults for various types. The `default` value is used if omitted:
 
 | JSON Schema Type | Format value | Generated variable type  |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ pip3 install cloudformation-cli-java-plugin
 
 Refer to the [CloudFormation CLI User Guide](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html) for the [CloudFormation CLI](https://github.com/aws-cloudformation/cloudformation-cli) for usage instructions.
 
+###Alternate Type Formats
+The `format` keyword can be specified on primitive types defined in a resource provider's schema to allow the CloudFormation CLI Java Plugin to generate more than the defaults for primitive types. Consult the table below for what formats are available and defaults for various types. The `default` value is used if omitted:
+
+| JSON Schema Type | Format value | Generated variable type  |
+| ---- | ----------- | ---------------------- |
+| boolean | `default` | [Boolean](https://docs.oracle.com/javase/8/docs/api/java/lang/Boolean.html)|
+| integer | `default`, `int32` | [Integer](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html)|
+| integer | `int64` | [Long](https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html)|
+| number | `default` | [Double](https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html)|
+| string | `default` | [String](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html)|
+
+For example, the below schema for a property would generate a variable of type `Long`.
+```
+{
+    "type": "integer",
+    "format": "int64"
+}
+```
+
+
 Development
 -----------
 

--- a/python/rpdk/java/resolver.py
+++ b/python/rpdk/java/resolver.py
@@ -1,4 +1,8 @@
-from rpdk.core.jsonutils.resolver import UNDEFINED, ContainerType
+import logging
+
+from rpdk.core.jsonutils.resolver import DEFAULT, UNDEFINED, ContainerType
+
+LOG = logging.getLogger(__name__)
 
 PRIMITIVE_TYPES = {
     "string": {"default": "String"},
@@ -13,7 +17,20 @@ def translate_type(resolved_type):
     if resolved_type.container == ContainerType.MODEL:
         return resolved_type.type
     if resolved_type.container == ContainerType.PRIMITIVE:
-        return PRIMITIVE_TYPES[resolved_type.type].get(resolved_type.type_format)
+        try:
+            primitive_format = PRIMITIVE_TYPES[resolved_type.type][
+                resolved_type.type_format
+            ]
+        except KeyError:
+            primitive_format = PRIMITIVE_TYPES[resolved_type.type][DEFAULT]
+            LOG.error(
+                "Could not find specified format '%s' for type '%s'. "
+                "Defaulting to '%s'",
+                resolved_type.type_format,
+                resolved_type.type,
+                primitive_format,
+            )
+        return primitive_format
 
     if resolved_type.container == ContainerType.MULTIPLE:
         return "Object"

--- a/python/rpdk/java/resolver.py
+++ b/python/rpdk/java/resolver.py
@@ -1,11 +1,15 @@
 from rpdk.core.jsonutils.resolver import UNDEFINED, ContainerType
 
 PRIMITIVE_TYPES = {
-    "string": "String",
-    "integer": "Integer",
-    "boolean": "Boolean",
-    "number": "Double",
-    UNDEFINED: "Object",
+    "string": {"default": "String"},
+    "integer": {
+                "default": "Integer",
+                "int32": "Integer",
+                "int64": "Integer"
+                },
+    "boolean": {"default": "Boolean"},
+    "number":  {"default": "Double"},
+    UNDEFINED: {"default": "Object"}
 }
 
 
@@ -13,7 +17,7 @@ def translate_type(resolved_type):
     if resolved_type.container == ContainerType.MODEL:
         return resolved_type.type
     if resolved_type.container == ContainerType.PRIMITIVE:
-        return PRIMITIVE_TYPES[resolved_type.type]
+        return PRIMITIVE_TYPES[resolved_type.type].get(resolved_type.format)
 
     if resolved_type.container == ContainerType.MULTIPLE:
         return "Object"

--- a/python/rpdk/java/resolver.py
+++ b/python/rpdk/java/resolver.py
@@ -2,14 +2,10 @@ from rpdk.core.jsonutils.resolver import UNDEFINED, ContainerType
 
 PRIMITIVE_TYPES = {
     "string": {"default": "String"},
-    "integer": {
-                "default": "Integer",
-                "int32": "Integer",
-                "int64": "Integer"
-                },
+    "integer": {"default": "Integer", "int32": "Integer", "int64": "Long"},
     "boolean": {"default": "Boolean"},
-    "number":  {"default": "Double"},
-    UNDEFINED: {"default": "Object"}
+    "number": {"default": "Double"},
+    UNDEFINED: {"default": "Object"},
 }
 
 
@@ -17,7 +13,7 @@ def translate_type(resolved_type):
     if resolved_type.container == ContainerType.MODEL:
         return resolved_type.type
     if resolved_type.container == ContainerType.PRIMITIVE:
-        return PRIMITIVE_TYPES[resolved_type.type].get(resolved_type.format)
+        return PRIMITIVE_TYPES[resolved_type.type].get(resolved_type.type_format)
 
     if resolved_type.container == ContainerType.MULTIPLE:
         return "Object"
@@ -25,7 +21,7 @@ def translate_type(resolved_type):
     item_type = translate_type(resolved_type.type)
 
     if resolved_type.container == ContainerType.DICT:
-        key_type = PRIMITIVE_TYPES["string"]
+        key_type = PRIMITIVE_TYPES["string"]["default"]
         return f"Map<{key_type}, {item_type}>"
     if resolved_type.container == ContainerType.LIST:
         return f"List<{item_type}>"

--- a/python/rpdk/java/resolver.py
+++ b/python/rpdk/java/resolver.py
@@ -1,6 +1,6 @@
 import logging
 
-from rpdk.core.jsonutils.resolver import DEFAULT, UNDEFINED, ContainerType
+from rpdk.core.jsonutils.resolver import FORMAT_DEFAULT, UNDEFINED, ContainerType
 
 LOG = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def translate_type(resolved_type):
                 resolved_type.type_format
             ]
         except KeyError:
-            primitive_format = PRIMITIVE_TYPES[resolved_type.type][DEFAULT]
+            primitive_format = PRIMITIVE_TYPES[resolved_type.type][FORMAT_DEFAULT]
             LOG.error(
                 "Could not find specified format '%s' for type '%s'. "
                 "Defaulting to '%s'",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # package_data -> use MANIFEST.in instead
     include_package_data=True,
     zip_safe=True,
-    install_requires=["cloudformation-cli>=0.1.4,<0.2"],
+    install_requires=["cloudformation-cli>=0.1.14,<0.2"],
     python_requires=">=3.6",
     entry_points={"rpdk.v1.languages": ["java = rpdk.java.codegen:JavaLanguagePlugin"]},
     license="Apache License 2.0",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -61,3 +61,8 @@ def test_translate_type_unknown(resolved_type, _java_type):
 @pytest.mark.parametrize("resolved_type,java_type", RESOLVED_INTEGER_FORMATS)
 def test_translate_type_integer_formats(resolved_type, java_type):
     assert translate_type(resolved_type) == java_type
+
+
+def test_translate_type_unavailable_format():
+    resolved_type = ResolvedType(ContainerType.PRIMITIVE, "integer", "int128")
+    assert translate_type(resolved_type) == PRIMITIVE_TYPES["integer"]["default"]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,13 +4,20 @@ from rpdk.java.resolver import PRIMITIVE_TYPES, translate_type
 
 RESOLVED_TYPES = [
     (ResolvedType(ContainerType.PRIMITIVE, item_type), formats["default"])
-    for item_type, native_type in PRIMITIVE_TYPES.items()
+    for item_type, formats in PRIMITIVE_TYPES.items()
 ]
 
-RESOLVED_TYPES = [
-    (ResolvedType(ContainerType.PRIMITIVE, item_type), PRIMITIVE_TYPES["integer"]["int64"]),
-(ResolvedType(ContainerType.PRIMITIVE, item_type), PRIMITIVE_TYPES["integer"]["int32"])
+RESOLVED_INTEGER_FORMATS = [
+    (
+        ResolvedType(ContainerType.PRIMITIVE, "integer", "int64"),
+        PRIMITIVE_TYPES["integer"]["int64"],
+    ),
+    (
+        ResolvedType(ContainerType.PRIMITIVE, "integer", "int32"),
+        PRIMITIVE_TYPES["integer"]["int32"],
+    ),
 ]
+
 
 def test_translate_type_model_passthrough():
     item_type = object()
@@ -50,6 +57,7 @@ def test_translate_type_unknown(resolved_type, _java_type):
     with pytest.raises(ValueError):
         translate_type(ResolvedType("foo", resolved_type))
 
+
 @pytest.mark.parametrize("resolved_type,java_type", RESOLVED_INTEGER_FORMATS)
 def test_translate_type_integer_formats(resolved_type, java_type):
-    assert translate_type(resolved_type) == native_type
+    assert translate_type(resolved_type) == java_type

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,10 +3,14 @@ from rpdk.core.jsonutils.resolver import MULTIPLE, ContainerType, ResolvedType
 from rpdk.java.resolver import PRIMITIVE_TYPES, translate_type
 
 RESOLVED_TYPES = [
-    (ResolvedType(ContainerType.PRIMITIVE, item_type), native_type)
+    (ResolvedType(ContainerType.PRIMITIVE, item_type), formats["default"])
     for item_type, native_type in PRIMITIVE_TYPES.items()
 ]
 
+RESOLVED_TYPES = [
+    (ResolvedType(ContainerType.PRIMITIVE, item_type), PRIMITIVE_TYPES["integer"]["int64"]),
+(ResolvedType(ContainerType.PRIMITIVE, item_type), PRIMITIVE_TYPES["integer"]["int32"])
+]
 
 def test_translate_type_model_passthrough():
     item_type = object()
@@ -45,3 +49,7 @@ def test_translate_type_set(resolved_type, native_type):
 def test_translate_type_unknown(resolved_type, _java_type):
     with pytest.raises(ValueError):
         translate_type(ResolvedType("foo", resolved_type))
+
+@pytest.mark.parametrize("resolved_type,java_type", RESOLVED_INTEGER_FORMATS)
+def test_translate_type_integer_formats(resolved_type, java_type):
+    assert translate_type(resolved_type) == native_type


### PR DESCRIPTION
*Issue #, if available:* #151, https://github.com/aws-cloudformation/cloudformation-cli/pull/621

*Description of changes:* Makes use of the additions in https://github.com/aws-cloudformation/cloudformation-cli/pull/621 to  generate "Long" primitive types when "int64" is specified as the integer format. Users can specify:

```
{
    "type": "integer",
    "format": "int64"
}
```
in their schema to generate a Long primitive in java. I also restructured the primitive types mapping to allow for additions of more formats in the future, if we want to support some natively supported jsonschema [string types](https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats) 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
