### PR TITLE
converter utility to cast multi-typed properties

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
+++ b/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
@@ -23,18 +23,27 @@ public class TypeConverter {
         throw new UnsupportedOperationException();
     }
 
-    public static <T> Object covertProperty(final Object input, final TypeReference<?>... typeReferences) // preserves order
-        throws IOException {
-        final Serializer serializer = new Serializer();
-        final String stringified_input = serializer.serialize(input);
+    public static Object covertProperty(final Object input, final TypeReference<?>... typeReferences) // preserves order
+    {
+        try {
+            final Serializer serializer = new Serializer();
+            final String stringified_input = serializer.serialize(input);
 
-        for (TypeReference<?> typeReference : typeReferences) {
-            try {
-                return serializer.deserialize(stringified_input, typeReference);
-            } catch (JsonProcessingException ignored) {
-                // An empty catch block
+            int iter = 0;
+            while (true) {
+                TypeReference<?> typeReference = typeReferences[iter];
+                try {
+                    return serializer.deserialize(stringified_input, typeReference);
+                } catch (JsonProcessingException exception) {
+                    if (iter < typeReferences.length - 1) {
+                        iter++;
+                    } else {
+                        throw new RuntimeException("No Suitable Type Reference");
+                    }
+                }
             }
+        } catch (IOException exception) {
+            throw new RuntimeException("Invalid Object to Stringify");
         }
-        return input; // if no suitable type references were provided we dont wanna fail
     }
 }

--- a/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
+++ b/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
@@ -1,0 +1,40 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+package software.amazon.cloudformation.resource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+
+public class TypeConverter {
+    protected TypeConverter() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static <T> Object covertProperty(final Object input, final TypeReference<?>... typeReferences) // preserves order
+        throws IOException {
+        final Serializer serializer = new Serializer();
+        final String stringified_input = serializer.serialize(input);
+
+        for (TypeReference<?> typeReference : typeReferences) {
+            try {
+                return serializer.deserialize(stringified_input, typeReference);
+            } catch (JsonProcessingException ignored) {
+                // An empty catch block
+            }
+        }
+        return input; // if no suitable type references were provided we dont wanna fail
+    }
+}

--- a/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
+++ b/src/main/java/software/amazon/cloudformation/resource/TypeConverter.java
@@ -23,7 +23,7 @@ public class TypeConverter {
         throw new UnsupportedOperationException();
     }
 
-    public static Object covertProperty(final Object input, final TypeReference<?>... typeReferences) // preserves order
+    public static Object convertProperty(final Object input, final TypeReference<?>... typeReferences) // preserves order
     {
         try {
             final Serializer serializer = new Serializer();

--- a/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
@@ -1,0 +1,82 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+package software.amazon.cloudformation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.List;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+public class TypeConverterTest {
+    @Data
+    public static class ComplexObject {
+        @JsonProperty("Key")
+        private String key;
+
+        @JsonProperty("Value")
+        private String value;
+    }
+
+    public static final String LIST_OF_OBJECTS = "[{\"Key\" : \"Key\",\"Value\" :\"Value\"},{\"Key\" : \"Key\",\"Value\":\"Value\"}]";
+    public static final String OBJECT = "{\"Key\" : \"Key\",\"Value\" : \"Value\"}";
+
+    final TypeReference<ComplexObject> typeReferenceComplexObject = new TypeReference<ComplexObject>() {
+    };
+    final TypeReference<List<ComplexObject>> typeReferenceComplexObjectList = new TypeReference<List<ComplexObject>>() {
+    };
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void castMultiTypePropertyToList() throws IOException {
+        final Serializer ser = new Serializer();
+
+        // mimics if multitype was casted to an object
+        final Object multiTypeProperty = ser.deserialize(LIST_OF_OBJECTS, new TypeReference<Object>() {
+        });
+
+        Object converted = TypeConverter.covertProperty(multiTypeProperty, typeReferenceComplexObject,
+            typeReferenceComplexObjectList);
+
+        assertThat(converted).isInstanceOf(List.class);
+
+        List<ComplexObject> complexObject = (List<ComplexObject>) converted;
+        assertThat(complexObject.size()).isEqualTo(2);
+        assertThat(complexObject.get(0)).isInstanceOf(ComplexObject.class);
+        assertThat(complexObject.get(0).key).isEqualTo("Key");
+        assertThat(complexObject.get(0).value).isEqualTo("Value");
+        assertThat(complexObject.get(1).key).isEqualTo("Key");
+        assertThat(complexObject.get(1).value).isEqualTo("Value");
+    }
+
+    @Test
+    public void castMultiTypePropertyToObject() throws IOException {
+        final Serializer ser = new Serializer();
+
+        // mimics if multitype was casted to an object
+        final Object multiTypeProperty = ser.deserialize(OBJECT, new TypeReference<Object>() {
+        });
+
+        Object converted = TypeConverter.covertProperty(multiTypeProperty, typeReferenceComplexObject,
+            typeReferenceComplexObjectList);
+        assertThat(converted).isInstanceOf(ComplexObject.class);
+        ComplexObject complexObject = (ComplexObject) converted;
+        assertThat(complexObject.key).isEqualTo("Key");
+        assertThat(complexObject.value).isEqualTo("Value");
+    }
+
+}

--- a/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
@@ -79,4 +79,22 @@ public class TypeConverterTest {
         assertThat(complexObject.value).isEqualTo("Value");
     }
 
+    @Test
+    public void castMultiTypePropertyWithInvalidReferences() throws IOException {
+        final Serializer ser = new Serializer();
+
+        // mimics if multitype was casted to an object
+        final Object multiTypeProperty = ser.deserialize(OBJECT, new TypeReference<Object>() {
+        });
+
+        try {
+            Object converted = TypeConverter.covertProperty(multiTypeProperty, new TypeReference<Integer>() {
+            }, new TypeReference<Boolean>() {
+            });
+
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("No Suitable Type Reference");
+        }
+    }
+
 }

--- a/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/TypeConverterTest.java
@@ -49,7 +49,7 @@ public class TypeConverterTest {
         final Object multiTypeProperty = ser.deserialize(LIST_OF_OBJECTS, new TypeReference<Object>() {
         });
 
-        Object converted = TypeConverter.covertProperty(multiTypeProperty, typeReferenceComplexObject,
+        Object converted = TypeConverter.convertProperty(multiTypeProperty, typeReferenceComplexObject,
             typeReferenceComplexObjectList);
 
         assertThat(converted).isInstanceOf(List.class);
@@ -71,7 +71,7 @@ public class TypeConverterTest {
         final Object multiTypeProperty = ser.deserialize(OBJECT, new TypeReference<Object>() {
         });
 
-        Object converted = TypeConverter.covertProperty(multiTypeProperty, typeReferenceComplexObject,
+        Object converted = TypeConverter.convertProperty(multiTypeProperty, typeReferenceComplexObject,
             typeReferenceComplexObjectList);
         assertThat(converted).isInstanceOf(ComplexObject.class);
         ComplexObject complexObject = (ComplexObject) converted;
@@ -88,7 +88,7 @@ public class TypeConverterTest {
         });
 
         try {
-            Object converted = TypeConverter.covertProperty(multiTypeProperty, new TypeReference<Integer>() {
+            Object converted = TypeConverter.convertProperty(multiTypeProperty, new TypeReference<Integer>() {
             }, new TypeReference<Boolean>() {
             });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

adding a utility class that helps to cast properties, which support multiple `type`/`$ref`, that were initially de serialized as `Object` types 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
