### PR TITLE
added metric for tagging

### DIFF
--- a/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
@@ -232,7 +232,8 @@ public abstract class AbstractWrapper<ResourceT, CallbackT> {
             // A response will be output on all paths, though CloudFormation will
             // not block on invoking the handlers, but rather listen for callbacks
             writeResponse(outputStream, handlerResponse, request);
-            publishExceptionCodeAndCountMetrics(request == null ? null : request.getAction(), handlerResponse.getErrorCode());
+            publishExceptionCodeAndCountMetrics(handlerResponse.getStatus(), request == null ? null : request.getAction(),
+                handlerResponse.getErrorCode(), handlerResponse.getMessage());
         }
     }
 
@@ -496,9 +497,13 @@ public abstract class AbstractWrapper<ResourceT, CallbackT> {
     /*
      * null-safe exception metrics delivery
      */
-    private void publishExceptionCodeAndCountMetrics(final Action action, final HandlerErrorCode handlerErrorCode) {
+    private void publishExceptionCodeAndCountMetrics(final OperationStatus status,
+                                                     final Action action,
+                                                     final HandlerErrorCode handlerErrorCode,
+                                                     final String message) {
         if (this.metricsPublisherProxy != null) {
-            this.metricsPublisherProxy.publishExceptionByErrorCodeAndCountBulkMetrics(Instant.now(), action, handlerErrorCode);
+            this.metricsPublisherProxy.publishExceptionByErrorCodeAndCountBulkMetrics(status, Instant.now(), action,
+                handlerErrorCode, message);
         }
     }
 

--- a/src/main/java/software/amazon/cloudformation/metrics/Metric.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/Metric.java
@@ -20,8 +20,10 @@ public class Metric {
     public static final String METRIC_NAME_HANDLER_EXCEPTION = "HandlerException";
     public static final String METRIC_NAME_HANDLER_EXCEPTION_BY_ERROR_CODE = "HandlerExceptionByErrorCode";
     public static final String METRIC_NAME_HANDLER_EXCEPTION_BY_EXCEPTION_COUNT = "HandlerExceptionByExceptionCount";
+    public static final String METRIC_NAME_HANDLER_EXCEPTION_DUE_TO_TAGGING = "HandlerExceptionByTagging";
     public static final String METRIC_NAME_HANDLER_DURATION = "HandlerInvocationDuration";
     public static final String METRIC_NAME_HANDLER_INVOCATION_COUNT = "HandlerInvocationCount";
+    public static final String ACCESS_DENIED_EXCEPTION_MESSAGE = "not authorized";
 
     public static final String DIMENSION_KEY_ACTION_TYPE = "Action";
     public static final String DIMENSION_KEY_EXCEPTION_TYPE = "ExceptionType";

--- a/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/MetricsPublisher.java
@@ -17,6 +17,7 @@ package software.amazon.cloudformation.metrics;
 import java.time.Instant;
 import software.amazon.cloudformation.Action;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
 
 public abstract class MetricsPublisher {
 
@@ -42,9 +43,11 @@ public abstract class MetricsPublisher {
                                        final HandlerErrorCode handlerErrorCode) {
     }
 
-    public void publishExceptionByErrorCodeAndCountBulkMetrics(final Instant timestamp,
+    public void publishExceptionByErrorCodeAndCountBulkMetrics(final OperationStatus status,
+                                                               final Instant timestamp,
                                                                final Action action,
-                                                               final HandlerErrorCode handlerErrorCode) {
+                                                               final HandlerErrorCode handlerErrorCode,
+                                                               final String message) {
     }
 
     public void publishInvocationMetric(final Instant timestamp, final Action action) {

--- a/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/MetricsPublisherProxy.java
@@ -35,11 +35,13 @@ public class MetricsPublisherProxy {
             .forEach(metricsPublisher -> metricsPublisher.publishExceptionMetric(timestamp, action, e, handlerErrorCode));
     }
 
-    public void publishExceptionByErrorCodeAndCountBulkMetrics(final Instant timestamp,
+    public void publishExceptionByErrorCodeAndCountBulkMetrics(final OperationStatus status,
+                                                               final Instant timestamp,
                                                                final Action action,
-                                                               final HandlerErrorCode handlerErrorCode) {
+                                                               final HandlerErrorCode handlerErrorCode,
+                                                               final String message) {
         metricsPublishers.stream().forEach(metricsPublisher -> metricsPublisher
-            .publishExceptionByErrorCodeAndCountBulkMetrics(timestamp, action, handlerErrorCode));
+            .publishExceptionByErrorCodeAndCountBulkMetrics(status, timestamp, action, handlerErrorCode, message));
     }
 
     public void publishInvocationMetric(final Instant timestamp, final Action action) {

--- a/src/test/java/software/amazon/cloudformation/WrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/WrapperTest.java
@@ -147,8 +147,8 @@ public class WrapperTest {
             // validation failure metric should be published for final error handling
             verify(providerMetricsPublisher).publishExceptionMetric(any(Instant.class), any(), any(TerminalException.class),
                 any(HandlerErrorCode.class));
-            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(Instant.class), any(),
-                any(HandlerErrorCode.class));
+            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(OperationStatus.class),
+                any(Instant.class), any(), any(HandlerErrorCode.class), any());
 
             // all metrics should be published even on terminal failure
             verify(providerMetricsPublisher).publishInvocationMetric(any(Instant.class), eq(action));
@@ -417,8 +417,8 @@ public class WrapperTest {
 
             }
 
-            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(Instant.class), eq(action),
-                any());
+            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(), any(Instant.class), eq(action),
+                any(), any());
 
             // validation failure metric should not be published
             verifyNoMoreInteractions(providerMetricsPublisher);
@@ -459,8 +459,8 @@ public class WrapperTest {
             // all metrics should be published, once for a single invocation
             verify(providerMetricsPublisher).publishInvocationMetric(any(Instant.class), eq(action));
             verify(providerMetricsPublisher).publishDurationMetric(any(Instant.class), eq(action), anyLong());
-            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(Instant.class), eq(action),
-                any());
+            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(), any(Instant.class), eq(action),
+                any(), any());
 
             // validation failure metric should not be published
             verifyNoMoreInteractions(providerMetricsPublisher);
@@ -825,8 +825,8 @@ public class WrapperTest {
             // verify initialiseRuntime was called and initialised dependencies
             verifyInitialiseRuntime();
 
-            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(Instant.class), any(Action.class),
-                any(HandlerErrorCode.class));
+            verify(providerMetricsPublisher).publishExceptionByErrorCodeAndCountBulkMetrics(any(OperationStatus.class),
+                any(Instant.class), any(Action.class), any(HandlerErrorCode.class), any(String.class));
 
             // no further calls to metrics publisher should occur
             verifyNoMoreInteractions(providerMetricsPublisher);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This code adds new metric - `HandlerExceptionByTagging`, which puts unit `1.0` if authorization failed on any tagging operations (`List*`, `Attach*`, `Remove*`), otherwise `0.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
