### PR TITLE
Fixed problem when original exception message was lost.

### DIFF
--- a/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/BaseHandlerException.java
@@ -22,7 +22,7 @@ public abstract class BaseHandlerException extends RuntimeException {
 
     private static final long serialVersionUID = -1646136434112354328L;
 
-    private HandlerErrorCode errorCode;
+    private final HandlerErrorCode errorCode;
 
     protected BaseHandlerException(final Throwable cause,
                                    final HandlerErrorCode errorCode) {
@@ -33,7 +33,7 @@ public abstract class BaseHandlerException extends RuntimeException {
     protected BaseHandlerException(final String message,
                                    final Throwable cause,
                                    final HandlerErrorCode errorCode) {
-        super(message, cause);
+        super(String.format("%s %s", message, cause.getMessage()), cause);
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnAccessDeniedException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnAccessDeniedException.java
@@ -26,7 +26,7 @@ public class CfnAccessDeniedException extends BaseHandlerException {
     }
 
     public CfnAccessDeniedException(final String operation) {
-        this(operation, null);
+        super(String.format(ERROR_CODE.getMessage(), operation), ERROR_CODE);
     }
 
     public CfnAccessDeniedException(final String operation,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnAlreadyExistsException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnAlreadyExistsException.java
@@ -27,7 +27,7 @@ public class CfnAlreadyExistsException extends BaseHandlerException {
 
     public CfnAlreadyExistsException(final String resourceTypeName,
                                      final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier), ERROR_CODE);
     }
 
     public CfnAlreadyExistsException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceException.java
@@ -26,7 +26,7 @@ public class CfnGeneralServiceException extends BaseHandlerException {
     }
 
     public CfnGeneralServiceException(final String operation) {
-        this(operation, null);
+        super(String.format(ERROR_CODE.getMessage(), operation), ERROR_CODE);
     }
 
     public CfnGeneralServiceException(final String operation,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnInternalFailureException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnInternalFailureException.java
@@ -22,7 +22,7 @@ public class CfnInternalFailureException extends BaseHandlerException {
     private static final HandlerErrorCode ERROR_CODE = HandlerErrorCode.InternalFailure;
 
     public CfnInternalFailureException() {
-        this(null);
+        super(ERROR_CODE.getMessage(), ERROR_CODE);
     }
 
     public CfnInternalFailureException(final Throwable cause) {

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidRequestException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidRequestException.java
@@ -26,7 +26,7 @@ public class CfnInvalidRequestException extends BaseHandlerException {
     }
 
     public CfnInvalidRequestException(final String requestBody) {
-        this(requestBody, null);
+        super(String.format(ERROR_CODE.getMessage(), requestBody), ERROR_CODE);
     }
 
     public CfnInvalidRequestException(final String requestBody,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnNetworkFailureException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnNetworkFailureException.java
@@ -26,7 +26,7 @@ public class CfnNetworkFailureException extends BaseHandlerException {
     }
 
     public CfnNetworkFailureException(final String operation) {
-        this(operation, null);
+        super(String.format(ERROR_CODE.getMessage(), operation), ERROR_CODE);
     }
 
     public CfnNetworkFailureException(final String operation,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnNotFoundException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnNotFoundException.java
@@ -27,7 +27,7 @@ public class CfnNotFoundException extends BaseHandlerException {
 
     public CfnNotFoundException(final String resourceTypeName,
                                 final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier), ERROR_CODE);
     }
 
     public CfnNotFoundException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedException.java
@@ -27,7 +27,7 @@ public class CfnNotStabilizedException extends BaseHandlerException {
 
     public CfnNotStabilizedException(final String resourceTypeName,
                                      final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier), ERROR_CODE);
     }
 
     public CfnNotStabilizedException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnNotUpdatableException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnNotUpdatableException.java
@@ -27,7 +27,7 @@ public class CfnNotUpdatableException extends BaseHandlerException {
 
     public CfnNotUpdatableException(final String resourceTypeName,
                                     final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier), ERROR_CODE);
     }
 
     public CfnNotUpdatableException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnServiceInternalErrorException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnServiceInternalErrorException.java
@@ -26,7 +26,7 @@ public class CfnServiceInternalErrorException extends BaseHandlerException {
     }
 
     public CfnServiceInternalErrorException(final String operation) {
-        this(operation, null);
+        super(String.format(ERROR_CODE.getMessage(), operation), ERROR_CODE);
     }
 
     public CfnServiceInternalErrorException(final String operation,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnServiceLimitExceededException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnServiceLimitExceededException.java
@@ -27,7 +27,7 @@ public class CfnServiceLimitExceededException extends BaseHandlerException {
 
     public CfnServiceLimitExceededException(final String resourceTypeName,
                                             final String reason) {
-        this(resourceTypeName, reason, null);
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, reason), ERROR_CODE);
     }
 
     public CfnServiceLimitExceededException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnThrottlingException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnThrottlingException.java
@@ -26,7 +26,7 @@ public class CfnThrottlingException extends BaseHandlerException {
     }
 
     public CfnThrottlingException(final String operation) {
-        this(operation, null);
+        super(String.format(ERROR_CODE.getMessage(), operation), ERROR_CODE);
     }
 
     public CfnThrottlingException(final String operation,

--- a/src/main/java/software/amazon/cloudformation/exceptions/ResourceAlreadyExistsException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/ResourceAlreadyExistsException.java
@@ -30,7 +30,7 @@ public class ResourceAlreadyExistsException extends CfnAlreadyExistsException {
 
     public ResourceAlreadyExistsException(final String resourceTypeName,
                                           final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(resourceTypeName, resourceIdentifier);
     }
 
     public ResourceAlreadyExistsException(final String resourceTypeName,

--- a/src/main/java/software/amazon/cloudformation/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/ResourceNotFoundException.java
@@ -30,7 +30,7 @@ public class ResourceNotFoundException extends CfnNotFoundException {
 
     public ResourceNotFoundException(final String resourceTypeName,
                                      final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+        super(resourceTypeName, resourceIdentifier);
     }
 
     public ResourceNotFoundException(final String resourceTypeName,

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnGeneralServiceExceptionTests.java
@@ -56,4 +56,11 @@ public class CfnGeneralServiceExceptionTests {
             throw new CfnGeneralServiceException(new RuntimeException("something wrong"));
         }).satisfies(exception -> assertEquals("something wrong", exception.getMessage()));
     }
+
+    @Test
+    public void cfnGeneralServiceException_detailedErrorMessage() {
+        assertThatExceptionOfType(CfnGeneralServiceException.class).isThrownBy(() -> {
+            throw new CfnGeneralServiceException("Some operation", new RuntimeException("something wrong"));
+        }).satisfies(exception -> assertEquals("Error occurred during operation 'Some operation'. something wrong", exception.getMessage()));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
When the exception was thrown with operation name the original errorMessage was lost.
For example
    
     throw new CfnGeneralServiceException("Operation", new RuntimeException("something happend");

results in "Error occurred during operation 'Operation'." message.
If operation parameter would not be passed then the message would contain "something happend". 

*Description of changes:*
I changed how Exceptions are constructed so behavior is consistent. If "operation" is passed in the original message is preserved. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
