### PR TITLE
Fix release failures due to double quoted Strings

### DIFF
--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: endsWith(github.ref, "-lib")
+    if: endsWith(github.ref, '-lib')
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_REGION: us-east-1

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: endsWith(github.ref, "-plugin")
+    if: endsWith(github.ref, '-plugin')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Small issue with release jobs appears to have made GitHub action endsWith checks requiring double quotes.

This changes the workflows to use single quotes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
