### PR TITLE
Marking NotStabilized Error Code as Terminal

### DIFF
--- a/src/main/java/software/amazon/cloudformation/proxy/HandlerErrorCode.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/HandlerErrorCode.java
@@ -73,7 +73,7 @@ public enum HandlerErrorCode {
 
     /**
      * the downstream resource failed to complete all of its ready state checks
-     * (Retriable)
+     * (Terminal)
      */
     NotStabilized(ExceptionMessages.NOT_STABILIZED),
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Marking NotStabilized Error Code as Terminal in HandlerErrorCode.java as it is not a retriable error code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
