### PR TITLE
add reason to CfnNotStabilizedException

### DIFF
--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedException.java
@@ -25,14 +25,62 @@ public class CfnNotStabilizedException extends BaseHandlerException {
         super(cause, ERROR_CODE);
     }
 
+    /**
+     * @param resourceTypeName
+     * @param resourceIdentifier
+     * @param reason Reason why the resource did not stabilize. This should include the current and
+     *               desired state.
+     *
+     *               Example: "Exceeded retry limit for DescribeResourceStatus.
+     *               Current Value: IN_PROGRESS. Desired Value: COMPLETE."
+     */
     public CfnNotStabilizedException(final String resourceTypeName,
-                                     final String resourceIdentifier) {
-        this(resourceTypeName, resourceIdentifier, null);
+                                     final String resourceIdentifier,
+                                     final String reason) {
+        this(resourceTypeName, resourceIdentifier, reason, null);
     }
 
+    /**
+     * @param resourceTypeName
+     * @param resourceIdentifier
+     * @param reason Reason why the resource did not stabilize. This should include the current and
+     *               desired state.
+     *
+     *               Example: "Exceeded retry limit for DescribeResourceStatus.
+     *               Current Value: IN_PROGRESS. Desired Value: COMPLETE."
+     * @param cause
+     */
+    public CfnNotStabilizedException(final String resourceTypeName,
+                                     final String resourceIdentifier,
+                                     final String reason,
+                                     final Throwable cause) {
+        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier, reason),
+            cause, ERROR_CODE);
+    }
+
+    /**
+     * use {@link #CfnNotStabilizedException(String, String, String)}
+     *
+     * @param resourceTypeName
+     * @param resourceIdentifier
+     */
+    @Deprecated
+    public CfnNotStabilizedException(final String resourceTypeName,
+                                     final String resourceIdentifier) {
+        this(resourceTypeName, resourceIdentifier, (Throwable) null);
+    }
+
+    /**
+     * use {@link #CfnNotStabilizedException(String, String, String, Throwable)}
+     *
+     * @param resourceTypeName
+     * @param resourceIdentifier
+     * @param cause
+     */
+    @Deprecated
     public CfnNotStabilizedException(final String resourceTypeName,
                                      final String resourceIdentifier,
                                      final Throwable cause) {
-        super(String.format(ERROR_CODE.getMessage(), resourceTypeName, resourceIdentifier), cause, ERROR_CODE);
+        this(resourceTypeName, resourceIdentifier, "", cause);
     }
 }

--- a/src/main/java/software/amazon/cloudformation/proxy/ExceptionMessages.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/ExceptionMessages.java
@@ -23,7 +23,7 @@ final class ExceptionMessages {
     static final String INVALID_REQUEST = "Invalid request provided: %s";
     static final String NETWORK_FAILURE = "Network failure occurred during operation '%s'.";
     static final String NOT_FOUND = "Resource of type '%s' with identifier '%s' was not found.";
-    static final String NOT_STABILIZED = "Resource of type '%s' with identifier '%s' did not stabilize.";
+    static final String NOT_STABILIZED = "Resource of type '%s' with identifier '%s' did not stabilize. %s";
     static final String NOT_UPDATABLE = "Resource of type '%s' with identifier '%s' is not updatable with parameters provided.";
     static final String RESOURCE_CONFLICT = "Resource of type '%s' with identifier '%s' has a conflict. Reason: %s.";
     static final String SERVICE_INTERNAL_ERROR = "Internal error reported from downstream service during operation '%s'.";

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnNotStabilizedExceptionTests.java
@@ -23,9 +23,9 @@ public class CfnNotStabilizedExceptionTests {
     @Test
     public void cfnNotStabilizedException_isBaseHandlerException() {
         assertThatExceptionOfType(BaseHandlerException.class).isThrownBy(() -> {
-            throw new CfnNotStabilizedException("AWS::Type::Resource", "myId", new RuntimeException());
+            throw new CfnNotStabilizedException("AWS::Type::Resource", "myId", "Reason", new RuntimeException());
         }).withCauseInstanceOf(RuntimeException.class).withMessageContaining("AWS::Type::Resource").withMessageContaining("myId")
-            .withMessageContaining("not stabilize");
+            .withMessageContaining("not stabilize").withMessageContaining("Reason");
     }
 
     @Test
@@ -38,9 +38,9 @@ public class CfnNotStabilizedExceptionTests {
     @Test
     public void cfnNotStabilizedException_noCauseGiven() {
         assertThatExceptionOfType(CfnNotStabilizedException.class).isThrownBy(() -> {
-            throw new CfnNotStabilizedException("AWS::Type::Resource", "myId");
+            throw new CfnNotStabilizedException("AWS::Type::Resource", "myId", "Reason");
         }).withNoCause().withMessageContaining("AWS::Type::Resource").withMessageContaining("myId")
-            .withMessageContaining("not stabilize");
+            .withMessageContaining("not stabilize").withMessageContaining("Reason");
     }
 
     @Test


### PR DESCRIPTION
The current stabilization error message "Resource of type '%s' with identifier '%s' did not stabilize." lacks a reason so users may not be able to determine the cause of the stabilization error.

### Changes
- add reason argument to CfnNotStabilizedException constructors with documentation
- update the corresponding NOT_STABILIZED exception message
- deprecate the old constructors

### Testing
- modified unit tests for new constructors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
