### PR TITLE
Adding extra condition to avoid subsequent validation

### DIFF
--- a/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
@@ -285,7 +285,7 @@ public abstract class AbstractWrapper<ResourceT, CallbackT, ConfigurationT> {
         // NOTE: Validation is not required on deletion as only the primary identifier
         // is required to delete.
         // Here, we want to surface ALL input validation errors to the caller.
-        final boolean shouldValidate = VALIDATING_ACTIONS.contains(request.getAction());
+        final boolean shouldValidate = VALIDATING_ACTIONS.contains(request.getAction()) && request.getCallbackContext() == null;
         if (shouldValidate) {
             // validate entire incoming payload, including extraneous fields which
             // are stripped by the Serializer (due to FAIL_ON_UNKNOWN_PROPERTIES setting)
@@ -388,8 +388,7 @@ public abstract class AbstractWrapper<ResourceT, CallbackT, ConfigurationT> {
 
     }
 
-    protected void writeResponse(final OutputStream outputStream,
-                                 final ProgressEvent<ResourceT, CallbackT> response)
+    protected void writeResponse(final OutputStream outputStream, final ProgressEvent<ResourceT, CallbackT> response)
         throws IOException {
         if (response.getResourceModel() != null) {
             // strip write only properties on final results, we will need the intact model

--- a/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidTypeConfigurationException.java
+++ b/src/main/java/software/amazon/cloudformation/exceptions/CfnInvalidTypeConfigurationException.java
@@ -1,3 +1,17 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
 package software.amazon.cloudformation.exceptions;
 
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
@@ -6,8 +20,9 @@ public class CfnInvalidTypeConfigurationException extends BaseHandlerException {
 
     private static final long serialVersionUID = -1646136434112354328L;
 
-    public CfnInvalidTypeConfigurationException(String resourceTypeName, String message) {
-        super(String.format(HandlerErrorCode.InvalidTypeConfiguration.getMessage(), resourceTypeName, message),
-            null, HandlerErrorCode.InvalidTypeConfiguration);
+    public CfnInvalidTypeConfigurationException(String resourceTypeName,
+                                                String message) {
+        super(String.format(HandlerErrorCode.InvalidTypeConfiguration.getMessage(), resourceTypeName, message), null,
+              HandlerErrorCode.InvalidTypeConfiguration);
     }
 }

--- a/src/test/java/software/amazon/cloudformation/data/create.without-callback-context.request.json
+++ b/src/test/java/software/amazon/cloudformation/data/create.without-callback-context.request.json
@@ -1,34 +1,34 @@
 {
-  "awsAccountId": "123456789012",
-  "bearerToken": "123456",
-  "region": "us-east-1",
-  "action": "CREATE",
-  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
-  "resourceType": "AWS::Test::TestModel",
-  "resourceTypeVersion": "1.0",
-  "requestData": {
-    "callerCredentials": {
-      "accessKeyId": "IASAYK835GAIFHAHEI23",
-      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
-      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestData": {
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "providerCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "providerLogGroupName": "providerLoggingGroupName",
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {},
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
+        }
     },
-    "providerCredentials": {
-      "accessKeyId": "HDI0745692Y45IUTYR78",
-      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
-      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
-    },
-    "providerLogGroupName": "providerLoggingGroupName",
-    "logicalResourceId": "myBucket",
-    "resourceProperties": {},
-    "systemTags": {
-      "aws:cloudformation:stack-id": "SampleStack"
-    },
-    "stackTags": {
-      "tag1": "abc"
-    },
-    "previousStackTags": {
-      "tag1": "def"
-    }
-  },
-  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
 }

--- a/src/test/java/software/amazon/cloudformation/data/create.without-callback-context.request.json
+++ b/src/test/java/software/amazon/cloudformation/data/create.without-callback-context.request.json
@@ -1,0 +1,34 @@
+{
+  "awsAccountId": "123456789012",
+  "bearerToken": "123456",
+  "region": "us-east-1",
+  "action": "CREATE",
+  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+  "resourceType": "AWS::Test::TestModel",
+  "resourceTypeVersion": "1.0",
+  "requestData": {
+    "callerCredentials": {
+      "accessKeyId": "IASAYK835GAIFHAHEI23",
+      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+    },
+    "providerCredentials": {
+      "accessKeyId": "HDI0745692Y45IUTYR78",
+      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+    },
+    "providerLogGroupName": "providerLoggingGroupName",
+    "logicalResourceId": "myBucket",
+    "resourceProperties": {},
+    "systemTags": {
+      "aws:cloudformation:stack-id": "SampleStack"
+    },
+    "stackTags": {
+      "tag1": "abc"
+    },
+    "previousStackTags": {
+      "tag1": "def"
+    }
+  },
+  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/src/test/java/software/amazon/cloudformation/data/update.without-callback-context.request.json
+++ b/src/test/java/software/amazon/cloudformation/data/update.without-callback-context.request.json
@@ -1,0 +1,35 @@
+{
+  "awsAccountId": "123456789012",
+  "bearerToken": "123456",
+  "region": "us-east-1",
+  "action": "UPDATE",
+  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+  "resourceType": "AWS::Test::TestModel",
+  "resourceTypeVersion": "1.0",
+  "requestData": {
+    "callerCredentials": {
+      "accessKeyId": "IASAYK835GAIFHAHEI23",
+      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+    },
+    "providerCredentials": {
+      "accessKeyId": "HDI0745692Y45IUTYR78",
+      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+    },
+    "providerLogGroupName": "providerLoggingGroupName",
+    "logicalResourceId": "myBucket",
+    "resourceProperties": {},
+    "previousResourceProperties": {},
+    "systemTags": {
+      "aws:cloudformation:stack-id": "SampleStack"
+    },
+    "stackTags": {
+      "tag1": "abc"
+    },
+    "previousStackTags": {
+      "tag1": "def"
+    }
+  },
+  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/src/test/java/software/amazon/cloudformation/data/update.without-callback-context.request.json
+++ b/src/test/java/software/amazon/cloudformation/data/update.without-callback-context.request.json
@@ -1,35 +1,35 @@
 {
-  "awsAccountId": "123456789012",
-  "bearerToken": "123456",
-  "region": "us-east-1",
-  "action": "UPDATE",
-  "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
-  "resourceType": "AWS::Test::TestModel",
-  "resourceTypeVersion": "1.0",
-  "requestData": {
-    "callerCredentials": {
-      "accessKeyId": "IASAYK835GAIFHAHEI23",
-      "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
-      "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "UPDATE",
+    "responseEndpoint": "https://cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestData": {
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "providerCredentials": {
+            "accessKeyId": "HDI0745692Y45IUTYR78",
+            "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
+            "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
+        },
+        "providerLogGroupName": "providerLoggingGroupName",
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {},
+        "previousResourceProperties": {},
+        "systemTags": {
+            "aws:cloudformation:stack-id": "SampleStack"
+        },
+        "stackTags": {
+            "tag1": "abc"
+        },
+        "previousStackTags": {
+            "tag1": "def"
+        }
     },
-    "providerCredentials": {
-      "accessKeyId": "HDI0745692Y45IUTYR78",
-      "secretAccessKey": "4976TUYVI234/5GW87ERYG823RF87GY9EIUH452I3",
-      "sessionToken": "842HYOFIQAEUDF78R8T7IU43HSADYGIFHBJSDHFA87SDF9PYvN1CEYASDUYFT5TQ97YASIHUDFAIUEYRISDKJHFAYSUDTFSDFADS"
-    },
-    "providerLogGroupName": "providerLoggingGroupName",
-    "logicalResourceId": "myBucket",
-    "resourceProperties": {},
-    "previousResourceProperties": {},
-    "systemTags": {
-      "aws:cloudformation:stack-id": "SampleStack"
-    },
-    "stackTags": {
-      "tag1": "abc"
-    },
-    "previousStackTags": {
-      "tag1": "def"
-    }
-  },
-  "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
 }

--- a/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidTypeConfigurationExceptionTests.java
+++ b/src/test/java/software/amazon/cloudformation/exceptions/CfnInvalidTypeConfigurationExceptionTests.java
@@ -1,3 +1,17 @@
+/*
+* Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
 package software.amazon.cloudformation.exceptions;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -9,8 +23,7 @@ public class CfnInvalidTypeConfigurationExceptionTests {
     public void cfnInvalidTypeConfigurationException_isBaseHandlerException() {
         assertThatExceptionOfType(BaseHandlerException.class).isThrownBy(() -> {
             throw new CfnInvalidTypeConfigurationException("AWS::Type::Resource", "<request>");
-        }).withNoCause().withMessageContaining("<request>")
-            .withMessageContaining("AWS::Type::Resource")
+        }).withNoCause().withMessageContaining("<request>").withMessageContaining("AWS::Type::Resource")
             .withMessageContaining("Invalid TypeConfiguration");
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding an extra logic to avoid unnecessary validation of the subsequent reinvocations.

Details, cfn should not validate request on reinvocation as request is subject to mutation by resource handlers

The change has been manually validated by @ugudip 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
