### PR TITLE
Remove hooks platform metrics

### DIFF
--- a/python/rpdk/java/templates/generate/hook/BaseHookConfiguration.java
+++ b/python/rpdk/java/templates/generate/hook/BaseHookConfiguration.java
@@ -44,7 +44,7 @@ public abstract class BaseHookConfiguration {
             new JSONTokener(
                 this.targetSchemas.computeIfAbsent(
                     targetName,
-                    tn -> this.getClass().getClassLoader().getResourceAsStream(tn)
+                    tn -> this.getClass().getClassLoader().getResourceAsStream(this.targetSchemaPaths.get(tn))
                 )
             )
         );

--- a/src/main/java/software/amazon/cloudformation/HookAbstractWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/HookAbstractWrapper.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.http.HttpStatusFamily;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cloudformation.encryption.Cipher;
 import software.amazon.cloudformation.encryption.KMSCipher;
 import software.amazon.cloudformation.exceptions.BaseHandlerException;
@@ -67,7 +66,6 @@ import software.amazon.cloudformation.proxy.hook.HookStatus;
 import software.amazon.cloudformation.resource.SchemaValidator;
 import software.amazon.cloudformation.resource.Serializer;
 import software.amazon.cloudformation.resource.Validator;
-import software.amazon.cloudformation.resource.exceptions.ValidationException;
 
 public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
 
@@ -199,19 +197,6 @@ public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
             // deserialize incoming payload to modeled request
             request = this.serializer.deserialize(input, typeReference);
             handlerResponse = processInvocation(rawInput, request);
-        } catch (final ValidationException e) {
-            String message;
-            String fullExceptionMessage = ValidationException.buildFullExceptionMessage(e);
-            if (!StringUtils.isEmpty(fullExceptionMessage)) {
-                message = String.format("Model validation failed (%s)", fullExceptionMessage);
-            } else {
-                message = "Model validation failed with unknown cause.";
-            }
-
-            handlerResponse = ProgressEvent.defaultFailureHandler(new TerminalException(message, e),
-                HandlerErrorCode.InvalidRequest);
-            publishExceptionMetric(request != null ? request.getActionInvocationPoint() : null, e,
-                HandlerErrorCode.InvalidRequest);
         } catch (final Throwable e) {
             // Exceptions are wrapped as a consistent error response to the caller (i.e;
             // CloudFormation)

--- a/src/main/java/software/amazon/cloudformation/HookAbstractWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/HookAbstractWrapper.java
@@ -90,7 +90,6 @@ public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
     final SchemaValidator validator;
     final TypeReference<HookInvocationRequest<ConfigurationT, CallbackT>> typeReference;
 
-    private MetricsPublisher platformMetricsPublisher;
     private MetricsPublisher providerMetricsPublisher;
 
     private CloudWatchLogHelper cloudWatchLogHelper;
@@ -112,7 +111,6 @@ public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
     public HookAbstractWrapper(final CredentialsProvider providerCredentialsProvider,
                                final CloudWatchLogPublisher providerEventsLogger,
                                final LogPublisher platformEventsLogger,
-                               final MetricsPublisher platformMetricsPublisher,
                                final MetricsPublisher providerMetricsPublisher,
                                final SchemaValidator validator,
                                final Serializer serializer,
@@ -123,7 +121,6 @@ public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
         this.cloudWatchLogsProvider = new CloudWatchLogsProvider(this.providerCredentialsProvider, httpClient);
         this.providerEventsLogger = providerEventsLogger;
         this.platformLogPublisher = platformEventsLogger;
-        this.platformMetricsPublisher = platformMetricsPublisher;
         this.providerMetricsPublisher = providerMetricsPublisher;
         this.serializer = serializer;
         this.validator = validator;
@@ -147,21 +144,13 @@ public abstract class HookAbstractWrapper<TargetT, CallbackT, ConfigurationT> {
         this.loggerProxy = new LoggerProxy();
         this.loggerProxy.addLogPublisher(this.platformLogPublisher);
 
+        // Initialisation skipped if dependencies were set during injection (in unit
+        // tests).
+
         // Initialize a KMS cipher to decrypt customer credentials in HookRequestData
         if (this.cipher == null && hookEncryptionKeyArn != null && hookEncryptionKeyRole != null) {
             this.cipher = new KMSCipher(hookEncryptionKeyArn, hookEncryptionKeyRole);
         }
-
-        // Initialisation skipped if dependencies were set during injection (in unit
-        // tests).
-        // e.g. "if (this.platformMetricsPublisher == null)"
-        if (this.platformMetricsPublisher == null) {
-            // platformMetricsPublisher needs aws account id to differentiate metrics
-            // namespace
-            this.platformMetricsPublisher = new HookMetricsPublisherImpl(this.platformLoggerProxy, awsAccountId, hookTypeName);
-        }
-        this.metricsPublisherProxy.addMetricsPublisher(this.platformMetricsPublisher);
-        this.platformMetricsPublisher.refreshClient();
 
         // NOTE: providerCredentials and providerLogGroupName are null/not null in
         // sync.

--- a/src/main/java/software/amazon/cloudformation/HookExecutableWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/HookExecutableWrapper.java
@@ -44,14 +44,13 @@ public abstract class HookExecutableWrapper<TargetT, CallbackT, ConfigurationT>
     public HookExecutableWrapper(final CredentialsProvider providerCredentialsProvider,
                                  final CloudWatchLogPublisher providerEventsLogger,
                                  final LogPublisher platformEventsLogger,
-                                 final MetricsPublisher platformMetricsPublisher,
                                  final MetricsPublisher providerMetricsPublisher,
                                  final SchemaValidator validator,
                                  final Serializer serializer,
                                  final SdkHttpClient httpClient,
                                  final Cipher cipher) {
-        super(providerCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, serializer, httpClient, cipher);
+        super(providerCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              serializer, httpClient, cipher);
     }
 
     public void handleRequest(final InputStream inputStream, final OutputStream outputStream) throws IOException,

--- a/src/main/java/software/amazon/cloudformation/HookLambdaWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/HookLambdaWrapper.java
@@ -43,14 +43,13 @@ public abstract class HookLambdaWrapper<TargetT, CallbackT, ConfigurationT>
     public HookLambdaWrapper(final CredentialsProvider providerCredentialsProvider,
                              final CloudWatchLogPublisher providerEventsLogger,
                              final LogPublisher platformEventsLogger,
-                             final MetricsPublisher platformMetricsPublisher,
                              final MetricsPublisher providerMetricsPublisher,
                              final SchemaValidator validator,
                              final Serializer serializer,
                              final SdkHttpClient httpClient,
                              final Cipher cipher) {
-        super(providerCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, serializer, httpClient, cipher);
+        super(providerCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              serializer, httpClient, cipher);
     }
 
     @Override

--- a/src/main/java/software/amazon/cloudformation/metrics/HookMetricsPublisherImpl.java
+++ b/src/main/java/software/amazon/cloudformation/metrics/HookMetricsPublisherImpl.java
@@ -19,8 +19,6 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
-import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
@@ -32,9 +30,7 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class HookMetricsPublisherImpl extends MetricsPublisher {
-    private static final String DEFAULT_REGION = "us-east-1";
-
-    private CloudWatchProvider cloudWatchProvider;
+    private final CloudWatchProvider cloudWatchProvider;
     private Logger loggerProxy;
     private String awsAccountId;
     private CloudWatchClient cloudWatchClient;
@@ -49,20 +45,9 @@ public class HookMetricsPublisherImpl extends MetricsPublisher {
         this.awsAccountId = awsAccountId;
     }
 
-    public HookMetricsPublisherImpl(final Logger loggerProxy,
-                                    final String awsAccountId,
-                                    final String hookTypeName) {
-        super(hookTypeName);
-        this.loggerProxy = loggerProxy;
-        this.awsAccountId = awsAccountId;
-        this.cloudWatchClient = createClient();
-    }
-
     @Override
     public void refreshClient() {
-        if (cloudWatchProvider != null) {
-            this.cloudWatchClient = cloudWatchProvider.get();
-        }
+        this.cloudWatchClient = cloudWatchProvider.get();
     }
 
     private String getHookTypeName() {
@@ -164,11 +149,6 @@ public class HookMetricsPublisherImpl extends MetricsPublisher {
         if (loggerProxy != null) {
             loggerProxy.log(String.format("%s%n", message));
         }
-    }
-
-    private CloudWatchClient createClient() {
-        final String region = SdkSystemSetting.AWS_REGION.getStringValue().map(Object::toString).orElse(DEFAULT_REGION);
-        return CloudWatchClient.builder().region(Region.of(region)).build();
     }
 
 }

--- a/src/test/java/software/amazon/cloudformation/HookExecutableWrapperOverride.java
+++ b/src/test/java/software/amazon/cloudformation/HookExecutableWrapperOverride.java
@@ -50,13 +50,12 @@ public class HookExecutableWrapperOverride extends HookExecutableWrapper<TestMod
     public HookExecutableWrapperOverride(final CredentialsProvider providerLoggingCredentialsProvider,
                                          final LogPublisher platformEventsLogger,
                                          final CloudWatchLogPublisher providerEventsLogger,
-                                         final MetricsPublisher platformMetricsPublisher,
                                          final MetricsPublisher providerMetricsPublisher,
                                          final SchemaValidator validator,
                                          final SdkHttpClient httpClient,
                                          final Cipher cipher) {
-        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, new Serializer(), httpClient, cipher);
+        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              new Serializer(), httpClient, cipher);
     }
 
     @Override

--- a/src/test/java/software/amazon/cloudformation/HookLambdaWrapperOverride.java
+++ b/src/test/java/software/amazon/cloudformation/HookLambdaWrapperOverride.java
@@ -50,13 +50,12 @@ public class HookLambdaWrapperOverride extends HookLambdaWrapper<TestModel, Test
     public HookLambdaWrapperOverride(final CredentialsProvider providerLoggingCredentialsProvider,
                                      final LogPublisher platformEventsLogger,
                                      final CloudWatchLogPublisher providerEventsLogger,
-                                     final MetricsPublisher platformMetricsPublisher,
                                      final MetricsPublisher providerMetricsPublisher,
                                      final SchemaValidator validator,
                                      final SdkHttpClient httpClient,
                                      final Cipher cipher) {
-        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, new Serializer(), httpClient, cipher);
+        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              new Serializer(), httpClient, cipher);
     }
 
     @Override

--- a/src/test/java/software/amazon/cloudformation/HookWrapperOverride.java
+++ b/src/test/java/software/amazon/cloudformation/HookWrapperOverride.java
@@ -66,13 +66,12 @@ public class HookWrapperOverride extends HookAbstractWrapper<TestModel, TestCont
     public HookWrapperOverride(final CredentialsProvider providerLoggingCredentialsProvider,
                                final LogPublisher platformEventsLogger,
                                final CloudWatchLogPublisher providerEventsLogger,
-                               final MetricsPublisher platformMetricsPublisher,
                                final MetricsPublisher providerMetricsPublisher,
                                final SchemaValidator validator,
                                final SdkHttpClient httpClient,
                                final Cipher cipher) {
-        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, new Serializer(), httpClient, cipher);
+        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              new Serializer(), httpClient, cipher);
     }
 
     @Override

--- a/src/test/java/software/amazon/cloudformation/proxy/handler/hook/HookServiceHandlerWrapper.java
+++ b/src/test/java/software/amazon/cloudformation/proxy/handler/hook/HookServiceHandlerWrapper.java
@@ -48,15 +48,14 @@ public class HookServiceHandlerWrapper extends HookLambdaWrapper<Model, StdCallb
     public HookServiceHandlerWrapper(final CredentialsProvider providerLoggingCredentialsProvider,
                                      final CloudWatchLogPublisher providerEventsLogger,
                                      final LogPublisher platformEventsLogger,
-                                     final MetricsPublisher platformMetricsPublisher,
                                      final MetricsPublisher providerMetricsPublisher,
                                      final SchemaValidator validator,
                                      final Serializer serializer,
                                      final ServiceClient client,
                                      final SdkHttpClient httpClient,
                                      final KMSCipher cipher) {
-        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, platformMetricsPublisher,
-              providerMetricsPublisher, validator, serializer, httpClient, cipher);
+        super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
+              serializer, httpClient, cipher);
         this.serviceClient = client;
     }
 


### PR DESCRIPTION
*Description of changes:*
* Removed CFN Platform metrics publishing in Hook Wrapper
* Removed catch statement for `ValidationException` as no actual schema validation happens in hook wrapper
* Fixed an error with loading a hook's target schema when generating the `BaseHookConfiguration` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
