### PR TITLE
Return AccessDenied Error Code when failing to decrypt credentials

### DIFF
--- a/src/main/java/software/amazon/cloudformation/encryption/KMSCipher.java
+++ b/src/main/java/software/amazon/cloudformation/encryption/KMSCipher.java
@@ -87,7 +87,13 @@ public class KMSCipher implements Cipher {
         try {
             final CryptoResult<byte[],
                 KmsMasterKey> result = cryptoHelper.decryptData(kmsKeyProvider, Base64.decode(encryptedCredentials));
-            return serializer.deserialize(new String(result.getResult(), StandardCharsets.UTF_8), this.credentialsTypeReference);
+            final Credentials credentials = serializer.deserialize(new String(result.getResult(), StandardCharsets.UTF_8),
+                this.credentialsTypeReference);
+            if (credentials == null) {
+                throw new EncryptionException("Failed to decrypt credentials. Decrypted credentials are 'null'.");
+            }
+
+            return credentials;
         } catch (final IOException | AwsCryptoException e) {
             throw new EncryptionException("Failed to decrypt credentials.", e);
         }

--- a/src/test/java/software/amazon/cloudformation/encryption/KMSCipherTest.java
+++ b/src/test/java/software/amazon/cloudformation/encryption/KMSCipherTest.java
@@ -15,16 +15,20 @@
 package software.amazon.cloudformation.encryption;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.CryptoResult;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.exceptions.EncryptionException;
 import software.amazon.cloudformation.proxy.Credentials;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,33 +57,76 @@ public class KMSCipherTest {
     public void decryptCredentials_decryptSuccess() {
         cipher = new KMSCipher(cryptoHelper, kmsKeyProvider);
         lenient().when(cryptoHelper.decryptData(any(KmsMasterKeyProvider.class), any(byte[].class))).thenReturn(result);
-        lenient().when(result.getResult()).thenReturn("{\"test\":\"test\"}".getBytes());
+        lenient().when(result.getResult()).thenReturn(
+            "{\"accessKeyId\":\"testAccessKeyId\", \"secretAccessKey\": \"testSecretAccessKey\", \"sessionToken\": \"testToken\"}"
+                .getBytes());
 
-        try {
-            Credentials decryptedCredentials = cipher
-                .decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
-                    + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
-                    + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
-                    + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
-                    + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==");
-            assertThat(decryptedCredentials).isNotNull();
-        } catch (final Exception ex) {
-        }
-
+        Credentials decryptedCredentials = cipher
+            .decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
+                + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
+                + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
+                + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
+                + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==");
+        assertThat(decryptedCredentials).isNotNull();
+        assertThat(decryptedCredentials.getAccessKeyId()).isEqualTo("testAccessKeyId");
+        assertThat(decryptedCredentials.getSecretAccessKey()).isEqualTo("testSecretAccessKey");
+        assertThat(decryptedCredentials.getSessionToken()).isEqualTo("testToken");
     }
 
     @Test
     public void decryptCredentials_decryptFailure() {
         cipher = new KMSCipher("encryptionKeyArn", "encryptionKeyRole");
-        try {
-            Credentials decryptedCredentials = cipher
-                .decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
-                    + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
-                    + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
-                    + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
-                    + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==");
-            assertThat(decryptedCredentials).isNotNull();
-        } catch (final Exception ex) {
-        }
+        assertThatThrownBy(
+            () -> cipher.decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
+                + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
+                + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
+                + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
+                + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==")).isInstanceOf(EncryptionException.class)
+                    .hasMessageContaining("Failed to decrypt credentials");
+    }
+
+    @Test
+    public void decryptCredentials_returnsNullCredentials_decryptFailure() {
+        cipher = new KMSCipher(cryptoHelper, kmsKeyProvider);
+        lenient().when(cryptoHelper.decryptData(any(KmsMasterKeyProvider.class), any(byte[].class))).thenReturn(result);
+        lenient().when(result.getResult()).thenReturn("null".getBytes());
+
+        assertThatThrownBy(
+            () -> cipher.decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
+                + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
+                + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
+                + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
+                + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==")).isInstanceOf(EncryptionException.class)
+                    .hasMessageContaining("Failed to decrypt credentials. Decrypted credentials are 'null'");
+    }
+
+    @Test
+    public void decryptCredentials_encryptionSDKError_decryptFailure() {
+        cipher = new KMSCipher(cryptoHelper, kmsKeyProvider);
+        lenient().when(cryptoHelper.decryptData(any(KmsMasterKeyProvider.class), any(byte[].class)))
+            .thenThrow(new AwsCryptoException());
+
+        assertThatThrownBy(
+            () -> cipher.decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
+                + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
+                + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
+                + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
+                + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==")).isInstanceOf(EncryptionException.class)
+                    .hasCauseInstanceOf(AwsCryptoException.class).hasMessageContaining("Failed to decrypt credentials");
+    }
+
+    @Test
+    public void decryptCredentials_deserializationError_decryptFailure() {
+        cipher = new KMSCipher(cryptoHelper, kmsKeyProvider);
+        lenient().when(cryptoHelper.decryptData(any(KmsMasterKeyProvider.class), any(byte[].class))).thenReturn(result);
+        lenient().when(result.getResult()).thenReturn("{test: test\"".getBytes());
+
+        assertThatThrownBy(
+            () -> cipher.decryptCredentials("ewogICAgICAgICAgICAiYWNjZXNzS2V5SWQiOiAiSUFTQVlLODM1R0FJRkhBSEVJMjMiLAogICAg\n"
+                + "ICAgICAgICAic2VjcmV0QWNjZXNzS2V5IjogIjY2aU9HUE41TG5wWm9yY0xyOEtoMjV1OEFiakhW\n"
+                + "bGx2NS9wb2gyTzAiLAogICAgICAgICAgICAic2Vzc2lvblRva2VuIjogImxhbWVIUzJ2UU9rblNI\n"
+                + "V2hkRllUeG0yZUpjMUpNbjlZQk5JNG5WNG1YdWU5NDVLUEw2REhmVzhFc1VRVDV6d3NzWUVDMU52\n"
+                + "WVA5eUQ2WTVzNWxLUjNjaGZsT0hQRnNJZTZlcWciCiAgICAgICAgfQ==")).isInstanceOf(EncryptionException.class)
+                    .hasCauseInstanceOf(IOException.class).hasMessageContaining("Failed to decrypt credentials");
     }
 }


### PR DESCRIPTION
For `HOOK` types, credentials are encrypted service side before invoking the hook. Credentials are decrypted while setting up the runtime before calling the authored handler code.  
  
Sometimes decryption of the credentials fails when customer is missing permissions for decrypting the credentials. This usually happens when customer specifies their own hook execution role.  
  
To avoid this being marked as an `InternalFailure` service side, having the Hook wrapper return an `AccessDenied` error code instead back to CFN whenever decryption of credentials fails


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.