### PR TITLE
Update code formatter to v22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: isort
     # language_version: python3.6
 - repo: https://github.com/ambv/black
-  rev: 21.7b0
+  rev: 22.3.0
   hooks:
   - id: black
     # language_version: python3.6


### PR DESCRIPTION
Our code formatter, Black, has a dependency on click which released a breaking change in v8.1.0. 

Upgrading Black version to 22.3.0 as that includes the fix as per this issue: https://github.com/psf/black/issues/2964


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
