### PR TITLE
Improving TagHelper, so it accounts for system tags in case of resource import

### DIFF
--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -96,10 +96,10 @@ public class TagHelper {
     public Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> previousTags = new HashMap<>();
 
-        // get previous system tags if your service supports CloudFormation system tags
-        if (handlerRequest.getPreviousSystemTags() != null) {
-            previousTags.putAll(handlerRequest.getPreviousSystemTags());
-        }
+        // TODO: get previous system tags if your service supports CloudFormation system tags
+        // if (handlerRequest.getPreviousSystemTags() != null) {
+        //     previousTags.putAll(handlerRequest.getPreviousSystemTags());
+        // }
 
         // get previous stack level tags from handlerRequest
         if (handlerRequest.getPreviousResourceTags() != null) {

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -116,7 +116,7 @@ public class TagHelper {
      *
      * If stack tags and resource tags are not merged together in Configuration class,
      * we will get new desired system (with `aws:cloudformation` prefix) and user defined tags from
-     * handlerRequest.getSystemTags() (system tags), 
+     * handlerRequest.getSystemTags() (system tags),
      * handlerRequest.getDesiredResourceTags() (stack tags),
      * handlerRequest.getDesiredResourceState().getTags() (resource tags).
      *

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -71,27 +71,6 @@ public class TagHelper {
     }
 
     /**
-     * generateTagsForCreate
-     *
-     * Generate tags to put into resource creation request.
-     * This includes user defined tags and system tags as well.
-     */
-    public final Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
-        final Map<String, String> tagMap = new HashMap<>();
-
-        // merge system tags with desired resource tags if your service supports CloudFormation system tags
-        tagMap.putAll(handlerRequest.getSystemTags());
-
-        if (handlerRequest.getDesiredResourceTags() != null) {
-            tagMap.putAll(handlerRequest.getDesiredResourceTags());
-        }
-
-        // TODO: get tags from resource model based on your tag property name
-        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
-        return Collections.unmodifiableMap(tagMap);
-    }
-
-    /**
      * shouldUpdateTags
      *
      * Determines whether user defined tags have been changed during update.
@@ -105,33 +84,66 @@ public class TagHelper {
     /**
      * getPreviouslyAttachedTags
      *
-     * If stack tags and resource tags are not merged together in Configuration class,
-     * we will get previous attached user defined tags from both handlerRequest.getPreviousResourceTags (stack tags)
+     * If stack tags and resource tags are not merged together in Configuration
+     * class,
+     * we will get previously attached system (with `aws:cloudformation` prefix) and
+     * user defined tags
+     * from handlerRequest.getPreviousSystemTags(),
+     * handlerRequest.getPreviousResourceTags (stack tags),
      * and handlerRequest.getPreviousResourceState (resource tags).
+     * System tags can change on resource update if the resource is imported to the
+     * stack.
      */
     public Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> previousTags = new HashMap<>();
+
+        // get previous system tags
+        if (handlerRequest.getPreviousSystemTags() != null) {
+            previousTags.putAll(handlerRequest.getPreviousSystemTags());
+        }
+
         // get previous stack level tags from handlerRequest
-        final Map<String, String> previousTags = handlerRequest.getPreviousResourceTags() != null ?
-            handlerRequest.getPreviousResourceTags() : Collections.emptyMap();
+        if (handlerRequest.getPreviousResourceTags() != null) {
+            previousTags.putAll(handlerRequest.getPreviousResourceTags());
+        }
 
         // TODO: get resource level tags from previous resource state based on your tag property name
-        // TODO: previousTags.putAll(handlerRequest.getPreviousResourceState().getTags());
+        // TODO:
+        // previousTags.putAll(handlerRequest.getPreviousResourceState().getTags()); //
+        // if tags are not null
         return previousTags;
     }
 
     /**
      * getNewDesiredTags
      *
-     * If stack tags and resource tags are not merged together in Configuration class,
-     * we will get new user defined tags from both resource model and previous stack tags.
+     * If stack tags and resource tags are not merged together in Configuration
+     * class,
+     * we will get new desired attached system (with `aws:cloudformation` prefix)
+     * and user defined tags
+     * from handlerRequest.getSystemTags(), handlerRequest.getPreviousResourceTags
+     * (stack tags),
+     * and handlerRequest.getPreviousResourceState (resource tags).
+     * System tags can change on resource update if the resource is imported to the
+     * stack.
      */
     public Map<String, String> getNewDesiredTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         // get new stack level tags from handlerRequest
-        final Map<String, String> desiredTags = handlerRequest.getDesiredResourceTags() != null ?
-            handlerRequest.getDesiredResourceTags() : Collections.emptyMap();
+        final Map<String, String> desiredTags = new HashMap<>();
+
+        // get system tags
+        if (handlerRequest.getSystemTags() != null) {
+            desiredTags.putAll(handlerRequest.getSystemTags());
+        }
+
+        // get desired stack level tags from handlerRequest
+        if (handlerRequest.getDesiredResourceTags() != null) {
+            desiredTags.putAll(handlerRequest.getDesiredResourceTags());
+        }
 
         // TODO: get resource level tags from resource model based on your tag property name
-        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags()));
+        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags())); // if tags
+        // are not null
         return desiredTags;
     }
 

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -128,7 +128,6 @@ public class TagHelper {
      * stack.
      */
     public Map<String, String> getNewDesiredTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
-        // get new stack level tags from handlerRequest
         final Map<String, String> desiredTags = new HashMap<>();
 
         // get system tags

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -89,7 +89,7 @@ public class TagHelper {
      * handlerRequest.getPreviousSystemTags() (system tags),
      * handlerRequest.getPreviousResourceTags() (stack tags),
      * handlerRequest.getPreviousResourceState().getTags() (resource tags).
-     * 
+     *
      * System tags are an optional feature. Merge them to your tags if you have enabled them for your resource.
      * System tags can change on resource update if the resource is imported to the stack.
      */
@@ -119,7 +119,7 @@ public class TagHelper {
      * handlerRequest.getSystemTags() (system tags), 
      * handlerRequest.getDesiredResourceTags() (stack tags),
      * handlerRequest.getDesiredResourceState().getTags() (resource tags).
-     * 
+     *
      * System tags are an optional feature. Merge them to your tags if you have enabled them for your resource.
      * System tags can change on resource update if the resource is imported to the stack.
      */

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -84,15 +84,12 @@ public class TagHelper {
     /**
      * getPreviouslyAttachedTags
      *
-     * If stack tags and resource tags are not merged together in Configuration
-     * class,
-     * we will get previously attached system (with `aws:cloudformation` prefix) and
-     * user defined tags
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get previously attached system (with `aws:cloudformation` prefix) and user defined tags
      * from handlerRequest.getPreviousSystemTags(),
      * handlerRequest.getPreviousResourceTags (stack tags),
      * and handlerRequest.getPreviousResourceState (resource tags).
-     * System tags can change on resource update if the resource is imported to the
-     * stack.
+     * System tags can change on resource update if the resource is imported to the stack.
      */
     public Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> previousTags = new HashMap<>();
@@ -109,23 +106,18 @@ public class TagHelper {
 
         // TODO: get resource level tags from previous resource state based on your tag property name
         // TODO:
-        // previousTags.putAll(handlerRequest.getPreviousResourceState().getTags()); //
-        // if tags are not null
+        // previousTags.putAll(handlerRequest.getPreviousResourceState().getTags()); // if tags are not null
         return previousTags;
     }
 
     /**
      * getNewDesiredTags
      *
-     * If stack tags and resource tags are not merged together in Configuration
-     * class,
-     * we will get new desired attached system (with `aws:cloudformation` prefix)
-     * and user defined tags
-     * from handlerRequest.getSystemTags(), handlerRequest.getPreviousResourceTags
-     * (stack tags),
+     * If stack tags and resource tags are not merged together in Configuration class,
+     * we will get new desired attached system (with `aws:cloudformation` prefix) and user defined tags
+     * from handlerRequest.getSystemTags(), handlerRequest.getPreviousResourceTags (stack tags),
      * and handlerRequest.getPreviousResourceState (resource tags).
-     * System tags can change on resource update if the resource is imported to the
-     * stack.
+     * System tags can change on resource update if the resource is imported to the stack.
      */
     public Map<String, String> getNewDesiredTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> desiredTags = new HashMap<>();
@@ -141,8 +133,7 @@ public class TagHelper {
         }
 
         // TODO: get resource level tags from resource model based on your tag property name
-        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags())); // if tags
-        // are not null
+        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags())); // if tags are not null
         return desiredTags;
     }
 

--- a/python/rpdk/java/templates/init/guided_aws/TagHelper.java
+++ b/python/rpdk/java/templates/init/guided_aws/TagHelper.java
@@ -85,16 +85,18 @@ public class TagHelper {
      * getPreviouslyAttachedTags
      *
      * If stack tags and resource tags are not merged together in Configuration class,
-     * we will get previously attached system (with `aws:cloudformation` prefix) and user defined tags
-     * from handlerRequest.getPreviousSystemTags(),
-     * handlerRequest.getPreviousResourceTags (stack tags),
-     * and handlerRequest.getPreviousResourceState (resource tags).
+     * we will get previously attached system (with `aws:cloudformation` prefix) and user defined tags from
+     * handlerRequest.getPreviousSystemTags() (system tags),
+     * handlerRequest.getPreviousResourceTags() (stack tags),
+     * handlerRequest.getPreviousResourceState().getTags() (resource tags).
+     * 
+     * System tags are an optional feature. Merge them to your tags if you have enabled them for your resource.
      * System tags can change on resource update if the resource is imported to the stack.
      */
     public Map<String, String> getPreviouslyAttachedTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> previousTags = new HashMap<>();
 
-        // get previous system tags
+        // get previous system tags if your service supports CloudFormation system tags
         if (handlerRequest.getPreviousSystemTags() != null) {
             previousTags.putAll(handlerRequest.getPreviousSystemTags());
         }
@@ -105,8 +107,7 @@ public class TagHelper {
         }
 
         // TODO: get resource level tags from previous resource state based on your tag property name
-        // TODO:
-        // previousTags.putAll(handlerRequest.getPreviousResourceState().getTags()); // if tags are not null
+        // TODO: previousTags.putAll(handlerRequest.getPreviousResourceState().getTags()); // if tags are not null
         return previousTags;
     }
 
@@ -114,18 +115,21 @@ public class TagHelper {
      * getNewDesiredTags
      *
      * If stack tags and resource tags are not merged together in Configuration class,
-     * we will get new desired attached system (with `aws:cloudformation` prefix) and user defined tags
-     * from handlerRequest.getSystemTags(), handlerRequest.getPreviousResourceTags (stack tags),
-     * and handlerRequest.getPreviousResourceState (resource tags).
+     * we will get new desired system (with `aws:cloudformation` prefix) and user defined tags from
+     * handlerRequest.getSystemTags() (system tags), 
+     * handlerRequest.getDesiredResourceTags() (stack tags),
+     * handlerRequest.getDesiredResourceState().getTags() (resource tags).
+     * 
+     * System tags are an optional feature. Merge them to your tags if you have enabled them for your resource.
      * System tags can change on resource update if the resource is imported to the stack.
      */
-    public Map<String, String> getNewDesiredTags(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+    public Map<String, String> getNewDesiredTags(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> desiredTags = new HashMap<>();
 
-        // get system tags
-        if (handlerRequest.getSystemTags() != null) {
-            desiredTags.putAll(handlerRequest.getSystemTags());
-        }
+        // TODO: merge system tags with desired resource tags if your service supports CloudFormation system tags
+        // if (handlerRequest.getSystemTags() != null) {
+        //     desiredTags.putAll(handlerRequest.getSystemTags());
+        // }
 
         // get desired stack level tags from handlerRequest
         if (handlerRequest.getDesiredResourceTags() != null) {
@@ -133,7 +137,7 @@ public class TagHelper {
         }
 
         // TODO: get resource level tags from resource model based on your tag property name
-        // TODO: desiredTags.putAll(convertToMap(resourceModel.getTags())); // if tags are not null
+        // TODO: desiredTags.putAll(convertToMap(handlerRequest.getDesiredResourceState().getTags())); // if tags are not null
         return desiredTags;
     }
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Improving TagHelper, so it accounts for system tags in case of resource import.
Current code is confusing because it creates an illusion that system tags should be set only once on resource create while they have to be set on update as well if a resource is imported. With this PR, `generateTagsForCreate` is not required at all because calling new edition of `getNewDesiredTags` will suffice for resource creation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
