### PR TITLE
Maintenance fixes to the POM file generation logic.

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -165,8 +165,8 @@ class JavaLanguagePlugin(LanguagePlugin):
         )
         project.safewrite(path, contents)
 
+    @staticmethod
     def _get_jacoco_maven_plugin_excluded_paths(
-        self,
         project,
     ):
         """Return a list of excluded paths based on the extension type."""

--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -206,12 +206,26 @@ class JavaLanguagePlugin(LanguagePlugin):
         LOG.debug("Writing Maven POM: %s", path)
         template = self.env.get_template("init/shared/pom.xml")
         artifact_id = "{}-handler".format(project.hypenated_name)
+        if project.artifact_type == ARTIFACT_TYPE_HOOK:
+            jacoco_maven_plugin_exclude_path_1 = "**/hook/model/**"
+            jacoco_maven_plugin_exclude_path_2 = "**/BaseHookConfiguration*"
+            jacoco_maven_plugin_exclude_path_3 = "**/HookHandlerWrapper*"
+            jacoco_maven_plugin_exclude_path_4 = "**/Configuration*"
+        else:
+            jacoco_maven_plugin_exclude_path_1 = "**/BaseConfiguration*"
+            jacoco_maven_plugin_exclude_path_2 = "**/BaseHandler*"
+            jacoco_maven_plugin_exclude_path_3 = "**/HandlerWrapper*"
+            jacoco_maven_plugin_exclude_path_4 = "**/ResourceModel*"
         contents = template.render(
             group_id=self.package_name,
             artifact_id=artifact_id,
             executable=EXECUTABLE,
             schema_file_name=project.schema_filename,
             package_name=self.package_name,
+            jacoco_maven_plugin_exclude_path_1=jacoco_maven_plugin_exclude_path_1,
+            jacoco_maven_plugin_exclude_path_2=jacoco_maven_plugin_exclude_path_2,
+            jacoco_maven_plugin_exclude_path_3=jacoco_maven_plugin_exclude_path_3,
+            jacoco_maven_plugin_exclude_path_4=jacoco_maven_plugin_exclude_path_4,
         )
         project.safewrite(path, contents)
 

--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -165,6 +165,26 @@ class JavaLanguagePlugin(LanguagePlugin):
         )
         project.safewrite(path, contents)
 
+    def _get_jacoco_maven_plugin_excluded_paths(
+        self,
+        project,
+    ):
+        """Return a list of excluded paths based on the extension type."""
+        jacoco_excluded_paths = []
+
+        if project.artifact_type == ARTIFACT_TYPE_HOOK:
+            jacoco_excluded_paths.append("**/hook/model/**")
+            jacoco_excluded_paths.append("**/BaseHookConfiguration*")
+            jacoco_excluded_paths.append("**/HookHandlerWrapper*")
+            jacoco_excluded_paths.append("**/Configuration*")
+        else:
+            jacoco_excluded_paths.append("**/BaseConfiguration*")
+            jacoco_excluded_paths.append("**/BaseHandler*")
+            jacoco_excluded_paths.append("**/HandlerWrapper*")
+            jacoco_excluded_paths.append("**/ResourceModel*")
+
+        return jacoco_excluded_paths
+
     @logdebug
     def init(self, project):
         """Init"""
@@ -206,26 +226,19 @@ class JavaLanguagePlugin(LanguagePlugin):
         LOG.debug("Writing Maven POM: %s", path)
         template = self.env.get_template("init/shared/pom.xml")
         artifact_id = "{}-handler".format(project.hypenated_name)
-        if project.artifact_type == ARTIFACT_TYPE_HOOK:
-            jacoco_maven_plugin_exclude_path_1 = "**/hook/model/**"
-            jacoco_maven_plugin_exclude_path_2 = "**/BaseHookConfiguration*"
-            jacoco_maven_plugin_exclude_path_3 = "**/HookHandlerWrapper*"
-            jacoco_maven_plugin_exclude_path_4 = "**/Configuration*"
-        else:
-            jacoco_maven_plugin_exclude_path_1 = "**/BaseConfiguration*"
-            jacoco_maven_plugin_exclude_path_2 = "**/BaseHandler*"
-            jacoco_maven_plugin_exclude_path_3 = "**/HandlerWrapper*"
-            jacoco_maven_plugin_exclude_path_4 = "**/ResourceModel*"
+        jacoco_excluded_paths = self._get_jacoco_maven_plugin_excluded_paths(
+            project=project,
+        )
         contents = template.render(
             group_id=self.package_name,
             artifact_id=artifact_id,
             executable=EXECUTABLE,
             schema_file_name=project.schema_filename,
             package_name=self.package_name,
-            jacoco_maven_plugin_exclude_path_1=jacoco_maven_plugin_exclude_path_1,
-            jacoco_maven_plugin_exclude_path_2=jacoco_maven_plugin_exclude_path_2,
-            jacoco_maven_plugin_exclude_path_3=jacoco_maven_plugin_exclude_path_3,
-            jacoco_maven_plugin_exclude_path_4=jacoco_maven_plugin_exclude_path_4,
+            jacoco_maven_plugin_exclude_path_1=jacoco_excluded_paths[0],
+            jacoco_maven_plugin_exclude_path_2=jacoco_excluded_paths[1],
+            jacoco_maven_plugin_exclude_path_3=jacoco_excluded_paths[2],
+            jacoco_maven_plugin_exclude_path_4=jacoco_excluded_paths[3],
         )
         project.safewrite(path, contents)
 

--- a/python/rpdk/java/templates/init/shared/pom.xml
+++ b/python/rpdk/java/templates/init/shared/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.3</version>
+            <version>2.17.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
@@ -172,10 +172,10 @@
                 <version>0.8.4</version>
                 <configuration>
                     <excludes>
-                        <exclude>**/BaseConfiguration*</exclude>
-                        <exclude>**/BaseHandler*</exclude>
-                        <exclude>**/HandlerWrapper*</exclude>
-                        <exclude>**/ResourceModel*</exclude>
+                        <exclude>{{ jacoco_maven_plugin_exclude_path_1 }}</exclude>
+                        <exclude>{{ jacoco_maven_plugin_exclude_path_2 }}</exclude>
+                        <exclude>{{ jacoco_maven_plugin_exclude_path_3 }}</exclude>
+                        <exclude>{{ jacoco_maven_plugin_exclude_path_4 }}</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
*Issue #, if available:*
Fixes aws-cloudformation/cloudformation-cli-java-plugin#412

*Description of changes:*
Updates to the generated POM file include: `log4j-slf4j-impl` version number pairing, and `jacoco-maven-plugin` dependency configuration to use discrete paths for CloudFormation extensions of type `resource` and `hook`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
