### PR TITLE
Use safe keyword when hook target namspace clashes with reserved java…

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -635,7 +635,7 @@ class JavaLanguagePlugin(LanguagePlugin):
             target_schema = target_info["Schema"]
 
             target_namespace = [
-                s.lower() for s in target_type_name.split("::")
+                safe_reserved(s.lower()) for s in target_type_name.split("::")
             ]  # AWS::SQS::Queue -> awssqsqueue
             target_name = "".join(
                 [s.capitalize() for s in target_namespace]


### PR DESCRIPTION
… keywords

*Issue #, if available:*

*Description of changes:*
Using a safe keyword that appends a `_` to the end of a nampspace if it is a reservered keyword in Java. This is updated for when generating POJOs for a Resource Hooks targets.

For example, the `AWS::Panorama::Package` resource was generating the following path: 
```
package com.mycompany.testing.mytesthook.model.aws.panorama.package;

public class AwsPanoramaPackage extends ResourceHookTarget {

...

}

------

public class AwsPanoramaPackageTargetModel extends ResourceHookTargetModel<AwsPanoramaPackage> {

...

}
```

Now a underscore is added so there is no name clashing causing complication errors for these certain resource types:
```
package com.mycompany.testing.mytesthook.model.aws.panorama.package_;

...

public class AwsPanoramaPackage_ extends ResourceHookTarget {

...

}

-----

public class AwsPanoramaPackage_TargetModel extends ResourceHookTargetModel<AwsPanoramaPackage_> {

...

}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
