### PR TITLE
feat: support Document type serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kendra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
         </dependency>
-        <!-- Test Dependencies -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -183,15 +183,17 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>kendra</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
         </dependency>
+        <!-- Test Dependencies -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kendra</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/software/amazon/cloudformation/proxy/aws/SdkPojoDeserializer.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/aws/SdkPojoDeserializer.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkField;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.core.document.Document;
+import software.amazon.awssdk.core.document.Document.ListBuilder;
 import software.amazon.awssdk.core.document.Document.MapBuilder;
 import software.amazon.awssdk.core.protocol.MarshallingType;
 import software.amazon.awssdk.core.traits.ListTrait;
@@ -219,11 +220,11 @@ public class SdkPojoDeserializer extends StdDeserializer<SdkPojo> {
             case VALUE_NUMBER_INT:
                 return Document.fromNumber(p.getText());
             case START_ARRAY: {
-                List<Document> documents = new ArrayList<>();
+                ListBuilder builder = Document.listBuilder();
                 while (p.nextToken() != JsonToken.END_ARRAY) {
-                    documents.add(readDocument(field, p, ctxt));
+                    builder.addDocument(readDocument(field, p, ctxt));
                 }
-                return Document.fromList(documents);
+                return builder.build();
             }
             case START_OBJECT:
                 MapBuilder builder = Document.mapBuilder();


### PR DESCRIPTION
*Issue #, if available:*
`AWS::Kendra::DataSource` reverted support for `TemplateConfiguration`. This is because the template present in the `TemplateConfiguration` was a `Document` type that was not supported by the `cloudformation-cli-java-plugin`. It seems that `template` was implemented as a string type when it was initially implemented, so `callGraphs' type resolution failed. This investigation is the cause I personally discovered in the process of cloning and debugging the source and trying to register and deploy it in the CloudFormation Registry.
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/pull/107

*Description of changes:*
Add support Document type. 
I have confirmed that if `TemplateConfiguration.Template` is implemented by the Document type, it can at least be deployed with CloudFormation Registry.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
