### PR TITLE
Verify hook handler with extraneous fields

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/Serializer.java
+++ b/src/main/java/software/amazon/cloudformation/resource/Serializer.java
@@ -36,14 +36,6 @@ import org.apache.commons.codec.binary.Base64;
 import software.amazon.cloudformation.proxy.aws.AWSServiceSerdeModule;
 
 public class Serializer {
-    public Serializer(Boolean strictDeserialize) {
-        this.strictDeserialize = strictDeserialize;
-    }
-
-    public Serializer() {
-        this.strictDeserialize = false;
-    }
-
     public static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };
     public static final String COMPRESSED = "__COMPRESSED__";
@@ -51,8 +43,6 @@ public class Serializer {
     private static final String COMPRESSION_GZIP_BASE64 = "gzip_base64";
     private static final ObjectMapper OBJECT_MAPPER;
     private static final ObjectMapper STRICT_OBJECT_MAPPER;
-
-    private final Boolean strictDeserialize;
 
     /**
      * Configures the specified ObjectMapper with the (de)serialization behaviours
@@ -91,6 +81,16 @@ public class Serializer {
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         OBJECT_MAPPER.registerModule(new AWSServiceSerdeModule());
         OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    }
+
+    private final Boolean strictDeserialize;
+
+    public Serializer(Boolean strictDeserialize) {
+        this.strictDeserialize = strictDeserialize;
+    }
+
+    public Serializer() {
+        this.strictDeserialize = false;
     }
 
     public <T> String serialize(final T modelObject) throws JsonProcessingException {

--- a/src/main/java/software/amazon/cloudformation/resource/Serializer.java
+++ b/src/main/java/software/amazon/cloudformation/resource/Serializer.java
@@ -36,6 +36,13 @@ import org.apache.commons.codec.binary.Base64;
 import software.amazon.cloudformation.proxy.aws.AWSServiceSerdeModule;
 
 public class Serializer {
+    public Serializer(Boolean strictDeserialize) {
+        this.strictDeserialize = strictDeserialize;
+    }
+
+    public Serializer() {
+        this.strictDeserialize = false;
+    }
 
     public static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };
@@ -44,6 +51,8 @@ public class Serializer {
     private static final String COMPRESSION_GZIP_BASE64 = "gzip_base64";
     private static final ObjectMapper OBJECT_MAPPER;
     private static final ObjectMapper STRICT_OBJECT_MAPPER;
+
+    private final Boolean strictDeserialize;
 
     /**
      * Configures the specified ObjectMapper with the (de)serialization behaviours
@@ -101,7 +110,11 @@ public class Serializer {
     }
 
     public <T> T deserialize(final String s, final TypeReference<T> reference) throws IOException {
-        return OBJECT_MAPPER.readValue(s, reference);
+        if (!strictDeserialize) {
+            return OBJECT_MAPPER.readValue(s, reference);
+        } else {
+            return deserializeStrict(s, reference);
+        }
     }
 
     public String decompress(final String s) throws IOException {

--- a/src/test/java/software/amazon/cloudformation/HookLambdaWrapperOverride.java
+++ b/src/test/java/software/amazon/cloudformation/HookLambdaWrapperOverride.java
@@ -53,9 +53,10 @@ public class HookLambdaWrapperOverride extends HookLambdaWrapper<TestModel, Test
                                      final MetricsPublisher providerMetricsPublisher,
                                      final SchemaValidator validator,
                                      final SdkHttpClient httpClient,
-                                     final Cipher cipher) {
+                                     final Cipher cipher,
+                                     final Boolean strictDeserialize) {
         super(providerLoggingCredentialsProvider, providerEventsLogger, platformEventsLogger, providerMetricsPublisher, validator,
-              new Serializer(), httpClient, cipher);
+              new Serializer(strictDeserialize), httpClient, cipher);
     }
 
     @Override

--- a/src/test/java/software/amazon/cloudformation/HookLambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/HookLambdaWrapperTest.java
@@ -90,10 +90,11 @@ public class HookLambdaWrapperTest {
     @BeforeEach
     public void initWrapper() {
         wrapper = new HookLambdaWrapperOverride(providerLoggingCredentialsProvider, platformEventsLogger, providerEventsLogger,
-                providerMetricsPublisher, validator, httpClient, cipher, false);
+                                                providerMetricsPublisher, validator, httpClient, cipher, false);
 
-        wrapperStrictDeserialize = new HookLambdaWrapperOverride(providerLoggingCredentialsProvider, platformEventsLogger, providerEventsLogger,
-                providerMetricsPublisher, validator, httpClient, cipher, true);
+        wrapperStrictDeserialize = new HookLambdaWrapperOverride(providerLoggingCredentialsProvider, platformEventsLogger,
+                                                                 providerEventsLogger, providerMetricsPublisher, validator,
+                                                                 httpClient, cipher, true);
     }
 
     private static InputStream loadRequestStream(final String fileName) {
@@ -174,16 +175,16 @@ public class HookLambdaWrapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"preCreate.request.with-resource-properties.json,CREATE_PRE_PROVISION"})
+    @CsvSource({ "preCreate.request.with-resource-properties.json,CREATE_PRE_PROVISION" })
     public void invokeHandler_WithResourceProperties_returnsSuccess(final String requestDataPath,
                                                                     final String invocationPointString)
-            throws IOException {
+        throws IOException {
         final HookInvocationPoint invocationPoint = HookInvocationPoint.valueOf(invocationPointString);
 
         // if the handler responds Complete, this is treated as a successful synchronous
         // completion
         final ProgressEvent<TestModel,
-                TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
+            TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
         wrapper.setInvokeHandlerResponse(pe);
 
         lenient().when(cipher.decryptCredentials(any())).thenReturn(new Credentials("123", "123", "123"));
@@ -200,7 +201,7 @@ public class HookLambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out,
-                    HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
+                HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
 
             // assert handler receives correct injections
             assertThat(wrapper.awsClientProxy).isNotNull();
@@ -211,16 +212,16 @@ public class HookLambdaWrapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"preCreate.request.with-resource-properties-and-extraneous-fields.json,CREATE_PRE_PROVISION"})
+    @CsvSource({ "preCreate.request.with-resource-properties-and-extraneous-fields.json,CREATE_PRE_PROVISION" })
     public void invokeHandler_WithResourcePropertiesAndExtraneousFields_returnsSuccess(final String requestDataPath,
                                                                                        final String invocationPointString)
-            throws IOException {
+        throws IOException {
         final HookInvocationPoint invocationPoint = HookInvocationPoint.valueOf(invocationPointString);
 
         // if the handler responds Complete, this is treated as a successful synchronous
         // completion
         final ProgressEvent<TestModel,
-                TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
+            TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
         wrapper.setInvokeHandlerResponse(pe);
 
         lenient().when(cipher.decryptCredentials(any())).thenReturn(new Credentials("123", "123", "123"));
@@ -237,7 +238,7 @@ public class HookLambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out,
-                    HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
+                HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
 
             // assert handler receives correct injections
             assertThat(wrapper.awsClientProxy).isNotNull();
@@ -248,16 +249,16 @@ public class HookLambdaWrapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"preCreate.request.with-resource-properties.json,CREATE_PRE_PROVISION"})
+    @CsvSource({ "preCreate.request.with-resource-properties.json,CREATE_PRE_PROVISION" })
     public void invokeHandler_StrictDeserializer_WithResourceProperties_returnsSuccess(final String requestDataPath,
                                                                                        final String invocationPointString)
-            throws IOException {
+        throws IOException {
         final HookInvocationPoint invocationPoint = HookInvocationPoint.valueOf(invocationPointString);
 
         // if the handler responds Complete, this is treated as a successful synchronous
         // completion
         final ProgressEvent<TestModel,
-                TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
+            TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
         wrapperStrictDeserialize.setInvokeHandlerResponse(pe);
 
         lenient().when(cipher.decryptCredentials(any())).thenReturn(new Credentials("123", "123", "123"));
@@ -274,7 +275,7 @@ public class HookLambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out,
-                    HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
+                HookProgressEvent.<TestContext>builder().clientRequestToken("123456").hookStatus(HookStatus.SUCCESS).build());
 
             // assert handler receives correct injections
             assertThat(wrapperStrictDeserialize.awsClientProxy).isNotNull();
@@ -285,13 +286,14 @@ public class HookLambdaWrapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"preCreate.request.with-resource-properties-and-extraneous-fields.json"})
-    public void invokeHandler_StrictDeserializer_WithResourcePropertiesAndExtraneousFields_returnsFailure(final String requestDataPath)
+    @CsvSource({ "preCreate.request.with-resource-properties-and-extraneous-fields.json" })
+    public void
+        invokeHandler_StrictDeserializer_WithResourcePropertiesAndExtraneousFields_returnsFailure(final String requestDataPath)
             throws IOException {
         // if the handler responds Complete, this is treated as a successful synchronous
         // completion
         final ProgressEvent<TestModel,
-                TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
+            TestContext> pe = ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build();
         wrapperStrictDeserialize.setInvokeHandlerResponse(pe);
 
         lenient().when(cipher.decryptCredentials(any())).thenReturn(new Credentials("123", "123", "123"));
@@ -309,7 +311,9 @@ public class HookLambdaWrapperTest {
 
             // verify output response
             verifyHandlerResponse(out,
-                    HookProgressEvent.<TestContext>builder().clientRequestToken(null).hookStatus(HookStatus.FAILED).errorCode(HandlerErrorCode.InternalFailure).callbackContext(null).message(expectedStringWhenStrictDeserializingWithExtraneousFields).build());
+                HookProgressEvent.<TestContext>builder().clientRequestToken(null).hookStatus(HookStatus.FAILED)
+                    .errorCode(HandlerErrorCode.InternalFailure).callbackContext(null)
+                    .message(expectedStringWhenStrictDeserializingWithExtraneousFields).build());
 
             // assert handler receives correct injections
             assertThat(wrapperStrictDeserialize.awsClientProxy).isNull();
@@ -319,17 +323,11 @@ public class HookLambdaWrapperTest {
         }
     }
 
-    private final String expectedStringWhenStrictDeserializingWithExtraneousFields = "Unrecognized field \"targetName\" (class software.amazon.cloudformation.proxy.hook.HookInvocationRequest), not marked as ignorable (10 known properties: \"requestContext\", \"stackId\", \"clientRequestToken\", \"hookModel\", \"hookTypeName\", \"requestData\", \"actionInvocationPoint\", \"awsAccountId\", \"changeSetId\", \"hookTypeVersion\"])\n" +
-            " at [Source: (String)\"{\n" +
-            "    \"clientRequestToken\": \"123456\",\n" +
-            "    \"awsAccountId\": \"123456789012\",\n" +
-            "    \"stackId\": \"arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968\",\n" +
-            "    \"changeSetId\": \"arn:aws:cloudformation:us-east-1:123456789012:changeSet/SampleChangeSet-conditional/1a2345b6-0000-00a0-a123-00abc0abc000\",\n" +
-            "    \"hookTypeName\": \"AWS::Test::TestModel\",\n" +
-            "    \"hookTypeVersion\": \"1.0\",\n" +
-            "    \"hookModel\": {\n" +
-            "        \"property1\": \"abc\",\n" +
-            "        \"property2\": 123\n" +
-            "    },\n" +
-            "    \"action\"[truncated 1935 chars]; line: 40, column: 20] (through reference chain: software.amazon.cloudformation.proxy.hook.HookInvocationRequest[\"targetName\"])";
+    private final String expectedStringWhenStrictDeserializingWithExtraneousFields = "Unrecognized field \"targetName\" (class software.amazon.cloudformation.proxy.hook.HookInvocationRequest), not marked as ignorable (10 known properties: \"requestContext\", \"stackId\", \"clientRequestToken\", \"hookModel\", \"hookTypeName\", \"requestData\", \"actionInvocationPoint\", \"awsAccountId\", \"changeSetId\", \"hookTypeVersion\"])\n"
+        + " at [Source: (String)\"{\n" + "    \"clientRequestToken\": \"123456\",\n" + "    \"awsAccountId\": \"123456789012\",\n"
+        + "    \"stackId\": \"arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968\",\n"
+        + "    \"changeSetId\": \"arn:aws:cloudformation:us-east-1:123456789012:changeSet/SampleChangeSet-conditional/1a2345b6-0000-00a0-a123-00abc0abc000\",\n"
+        + "    \"hookTypeName\": \"AWS::Test::TestModel\",\n" + "    \"hookTypeVersion\": \"1.0\",\n" + "    \"hookModel\": {\n"
+        + "        \"property1\": \"abc\",\n" + "        \"property2\": 123\n" + "    },\n"
+        + "    \"action\"[truncated 1935 chars]; line: 40, column: 20] (through reference chain: software.amazon.cloudformation.proxy.hook.HookInvocationRequest[\"targetName\"])";
 }

--- a/src/test/java/software/amazon/cloudformation/data/hook/preCreate.request.with-resource-properties-and-extraneous-fields.json
+++ b/src/test/java/software/amazon/cloudformation/data/hook/preCreate.request.with-resource-properties-and-extraneous-fields.json
@@ -1,0 +1,62 @@
+{
+    "clientRequestToken": "123456",
+    "awsAccountId": "123456789012",
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968",
+    "changeSetId": "arn:aws:cloudformation:us-east-1:123456789012:changeSet/SampleChangeSet-conditional/1a2345b6-0000-00a0-a123-00abc0abc000",
+    "hookTypeName": "AWS::Test::TestModel",
+    "hookTypeVersion": "1.0",
+    "hookModel": {
+        "property1": "abc",
+        "property2": 123
+    },
+    "actionInvocationPoint": "CREATE_PRE_PROVISION",
+    "requestData": {
+        "targetName": "AWS::Example::ResourceTarget",
+        "targetType": "RESOURCE",
+        "targetLogicalId": "myResource",
+        "targetModel": {
+            "resourceProperties": {
+                "BucketName": "someBucketName",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "BucketKeyEnabled": true,
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "aws:kms",
+                                "KMSMasterKeyID": "someKMSMasterKeyID"
+                            }
+                        }
+                    ]
+                }
+            },
+            "previousResourceProperties": null
+        },
+        "callerCredentials": "callerCredentials",
+        "providerCredentials": "providerCredentials",
+        "providerLogGroupName": "providerLoggingGroupName",
+        "hookEncryptionKeyArn": "hookEncryptionKeyArn",
+        "hookEncryptionKeyRole": "hookEncryptionKeyRole"
+    },
+    "targetName": "STACK",
+    "template": "<Original json template as string>",
+    "previousTemplate": "<Original json template as string>",
+    "changedResources": [
+        {
+            "logicalId": "MyBucket",
+            "typeName": "AWS::S3::Bucket",
+            "lineNumber": 3,
+            "action": "CREATE",
+            "beforeContext": "<Resource Properties as json string>",
+            "afterContext": "<Resource Properties as json string>"
+        },
+        {
+            "logicalId": "MyBucketPolicy",
+            "typeName": "AWS::S3::BucketPolicy",
+            "lineNumber": 15,
+            "action": "CREATE",
+            "beforeContext": "<Resource Properties as json string>",
+            "afterContext": "<Resource Properties as json string>"
+        }
+    ],
+    "requestContext": {}
+}

--- a/src/test/java/software/amazon/cloudformation/data/hook/preCreate.request.with-resource-properties.json
+++ b/src/test/java/software/amazon/cloudformation/data/hook/preCreate.request.with-resource-properties.json
@@ -1,0 +1,41 @@
+{
+    "clientRequestToken": "123456",
+    "awsAccountId": "123456789012",
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968",
+    "changeSetId": "arn:aws:cloudformation:us-east-1:123456789012:changeSet/SampleChangeSet-conditional/1a2345b6-0000-00a0-a123-00abc0abc000",
+    "hookTypeName": "AWS::Test::TestModel",
+    "hookTypeVersion": "1.0",
+    "hookModel": {
+        "property1": "abc",
+        "property2": 123
+    },
+    "actionInvocationPoint": "CREATE_PRE_PROVISION",
+    "requestData": {
+        "targetName": "AWS::Example::ResourceTarget",
+        "targetType": "RESOURCE",
+        "targetLogicalId": "myResource",
+        "targetModel": {
+            "resourceProperties": {
+                "BucketName": "someBucketName",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "BucketKeyEnabled": true,
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "aws:kms",
+                                "KMSMasterKeyID": "someKMSMasterKeyID"
+                            }
+                        }
+                    ]
+                }
+            },
+            "previousResourceProperties": null
+        },
+        "callerCredentials": "callerCredentials",
+        "providerCredentials": "providerCredentials",
+        "providerLogGroupName": "providerLoggingGroupName",
+        "hookEncryptionKeyArn": "hookEncryptionKeyArn",
+        "hookEncryptionKeyRole": "hookEncryptionKeyRole"
+    },
+    "requestContext": {}
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*


Add unit tests to verify that hook handlers can handle input that include extraneous inputs. The extra fields are not part of the target model, but the deserialization will continue to work.

Add unit tests with strict deserializing to verify the negative case.
