### PR TITLE
Fix method name collisions for getProperties()

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ source env/bin/activate
 pip3 install -e /path/to/cloudformation-cli-java-plugin
 ```
 
+Install `pytest-cov`, used when running unit tests for this plugin:
+
+```shell
+pip3 install pytest-cov
+```
+
 You may also want to check out the [CloudFormation CLI](https://github.com/aws-cloudformation/cloudformation-cli) if you wish to make edits to that. In this case, installing them in one operation works well:
 
 ```shell

--- a/python/rpdk/java/utils.py
+++ b/python/rpdk/java/utils.py
@@ -58,8 +58,28 @@ LANGUAGE_KEYWORDS = {
 }
 
 
+# Keywords used in the context of AWS CloudFormation Hooks. For
+# example, the `properties` item below is excluded because if a target
+# resource type has a property called `properties` (see the
+# `AWS::ApiGateway::DocumentationPart` resource type as one of the
+# examples), the generated class code for the target resource type
+# will contain a getter, `getProperties()`, that will collide with
+# `getProperties()` that is already defined for
+# `ResourceHookTarget`. By excluding `properties`, the generated code
+# for the class will still have a private variable, but whose name
+# will contain an underscore as a suffix: the Lombok-generated getter
+# (and setter) for that private variable will, in turn, contain an
+# underscore suffix as well; see `safe_reserved()` below for the
+# implementation of this behavior (`safe_reserved()` is, in turn,
+# consumed by other parts of the code generation logic in this
+# plugin).
+HOOKS_KEYWORDS = {
+    "properties",
+}
+
+
 def safe_reserved(token):
-    if token in LANGUAGE_KEYWORDS:
+    if token in LANGUAGE_KEYWORDS or token in HOOKS_KEYWORDS:
         return token + "_"
     return token
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix method name collisions for `getProperties()` when a target resource type has a `Properties` property defined, and Lombok-generated getters (and setters) are named `getProperties()` (and `setProperties()`, respectively), whereas the former collides with `getProperties()` already defined for `ResourceHookTarget`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
