### PR TITLE
Update sonatype plugins in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>


### PR DESCRIPTION
Update org.sonatype.plugins from 1.6.8 to 1.6.13 to resolve maven deployment error:

*nexus-staging-maven-plugin: maven deploy failed: An API incompatibility was encountered while executing*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
