### PR TITLE
Chore: disable redundant validation from the handler execution

### DIFF
--- a/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
+++ b/src/main/java/software/amazon/cloudformation/AbstractWrapper.java
@@ -76,7 +76,10 @@ public abstract class AbstractWrapper<ResourceT, CallbackT, ConfigurationT> {
     public static final SdkHttpClient HTTP_CLIENT = ApacheHttpClient.builder().build();
 
     private static final Set<Action> MUTATING_ACTIONS = ImmutableSet.of(Action.CREATE, Action.DELETE, Action.UPDATE);
-    private static final Set<Action> VALIDATING_ACTIONS = ImmutableSet.of(Action.CREATE, Action.UPDATE);
+
+    // Soft disable redundant schema validation
+    // Next action remove all validation code
+    private static final Set<Action> VALIDATING_ACTIONS = ImmutableSet.of();
 
     protected final Serializer serializer;
     protected LoggerProxy loggerProxy;

--- a/src/test/java/software/amazon/cloudformation/ExecutableWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/ExecutableWrapperTest.java
@@ -17,7 +17,6 @@ package software.amazon.cloudformation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.ByteArrayOutputStream;
@@ -27,7 +26,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -132,11 +130,6 @@ public class ExecutableWrapperTest {
 
             // verify initialiseRuntime was called and initialised dependencies
             verifyInitialiseRuntime();
-
-            // verify that model validation occurred for CREATE/UPDATE
-            if (action == Action.CREATE || action == Action.UPDATE) {
-                verify(validator, times(1)).validateObject(any(JSONObject.class), any(JSONObject.class));
-            }
 
             // verify output response
             verifyHandlerResponse(out, ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build());

--- a/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
+++ b/src/test/java/software/amazon/cloudformation/LambdaWrapperTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
@@ -30,7 +29,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -145,11 +143,6 @@ public class LambdaWrapperTest {
 
             // verify initialiseRuntime was called and initialised dependencies
             verifyInitialiseRuntime();
-
-            // verify that model validation occurred for CREATE/UPDATE
-            if (action == Action.CREATE || action == Action.UPDATE) {
-                verify(validator, times(1)).validateObject(any(JSONObject.class), any(JSONObject.class));
-            }
 
             // verify output response
             verifyHandlerResponse(out, ProgressEvent.<TestModel, TestContext>builder().status(OperationStatus.SUCCESS).build());


### PR DESCRIPTION
*Description of changes:* 
This change disables the redundant schema validation from the handler execution. It is redundant, because the schema validation also happens at service's side

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
