### PR TITLE
Fix IdentifierUtils unit tests

### DIFF
--- a/src/main/java/software/amazon/cloudformation/resource/IdentifierUtils.java
+++ b/src/main/java/software/amazon/cloudformation/resource/IdentifierUtils.java
@@ -23,8 +23,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 
 public class IdentifierUtils {
 
+    public static final int GUID_LENGTH = 12;
     private static final int GENERATED_PHYSICALID_MAXLEN = 40;
-    private static final int GUID_LENGTH = 12;
     private static final int MIN_PHYSICAL_RESOURCE_ID_LENGTH = 15;
     private static final int MIN_PREFERRED_LENGTH = 17;
     private static final Splitter STACKID_SPLITTER = Splitter.on('/');

--- a/src/test/java/software/amazon/cloudformation/resource/IdentifierUtilsTest.java
+++ b/src/test/java/software/amazon/cloudformation/resource/IdentifierUtilsTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 public class IdentifierUtilsTest {
+    private static final String guidPattern = "[a-zA-Z0-9]{" + IdentifierUtils.GUID_LENGTH + "}$";
+
     @Test
     public void generateResourceIdentifier_withDefaultLength() {
         String result = IdentifierUtils.generateResourceIdentifier("my-resource", "123456");
@@ -88,7 +90,7 @@ public class IdentifierUtilsTest {
             "arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack-name/084c0bd1-082b-11eb-afdc-0a2fadfa68a5",
             "my-resource", "123456", 255);
         assertThat(result.length()).isLessThanOrEqualTo(44);
-        assertThat(result).isEqualTo("my-stack-name-my-resource-hDoP0dahAFjd");
+        assertThat(result).matches("^my-stack-name-my-resource-" + IdentifierUtilsTest.guidPattern);
     }
 
     @Test
@@ -97,7 +99,7 @@ public class IdentifierUtilsTest {
             "arn:aws:cloudformation:us-east-1:123456789012:stack/my-very-very-very-very-very-very-long-custom-stack-name/084c0bd1-082b-11eb-afdc-0a2fadfa68a5",
             "abc", "123456", 36);
         assertThat(result.length()).isLessThanOrEqualTo(36);
-        assertThat(result).isEqualTo("my-very-very-very-v-abc-hDoP0dahAFjd");
+        assertThat(result).matches("^my-very-very-very-v-abc-" + IdentifierUtilsTest.guidPattern);
     }
 
     @Test
@@ -105,7 +107,7 @@ public class IdentifierUtilsTest {
         String result = IdentifierUtils.generateResourceIdentifier("abc",
             "my-very-very-very-very-very-very-long-custom-logical-id", "123456", 36);
         assertThat(result.length()).isLessThanOrEqualTo(36);
-        assertThat(result).isEqualTo("abc-my-very-very-very-v-hDoP0dahAFjd");
+        assertThat(result).matches("^abc-my-very-very-very-v-" + IdentifierUtilsTest.guidPattern);
     }
 
     @Test
@@ -114,7 +116,7 @@ public class IdentifierUtilsTest {
             "arn:aws:cloudformation:us-east-1:123456789012:stack/my-very-very-very-very-very-very-long-custom-stack-name/084c0bd1-082b-11eb-afdc-0a2fadfa68a5",
             "my-very-very-very-very-very-very-long-custom-logical-id", "123456", 36);
         assertThat(result.length()).isEqualTo(36);
-        assertThat(result).isEqualTo("my-very-ver-my-very-ver-hDoP0dahAFjd");
+        assertThat(result).matches("^my-very-ver-my-very-ver-" + IdentifierUtilsTest.guidPattern);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:* We were checking a randomly generated string against a hardcoded value, so I changed it to test against the expected pattern instead. This is not used directly inside this repo at any point. This is a tool that can be used by downstream users, to generate user friendly resource names for named resources whenever the customer doesn't pass in an explicit name. It's supposed to be used in create scenarios to create a resource name when that's missing, so we shouldn't need the id to be consistently generated in value, only in format.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
