### PR TITLE
fix(deps): Bump vulnerable dependencies to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.cloudformation</groupId>
     <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
     <name>AWS CloudFormation RPDK Java Plugin</name>
     <description>The CloudFormation Resource Provider Development Kit (RPDK) allows you to author your own resource providers that can be used by CloudFormation. This plugin library helps to provide runtime bindings for the execution of your providers by CloudFormation.
     </description>
@@ -40,11 +40,11 @@
         <awssdk.version>2.19.0</awssdk.version>
         <checkstyle.version>8.36.2</checkstyle.version>
         <commons-io.version>2.14.0</commons-io.version>
-        <jackson.version>2.14.1</jackson.version>
+        <jackson.version>2.17.2</jackson.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <mockito.version>3.12.4</mockito.version>
         <spotbugs.version>4.5.3.0</spotbugs.version>
-        <spotless.version>2.28.0</spotless.version>
+        <spotless.version>2.40.0</spotless.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     </properties>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.367</version>
+            <version>1.12.770</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-core -->
         <dependency>
@@ -130,19 +130,19 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.0</version>
         </dependency>
         <!--https://mvnrepository.com/artifact/com.amazonaws/aws-encryption-sdk-java -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>2.2.0</version>
+            <version>2.4.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-sts -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>1.12.368</version>
+            <version>1.12.770</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.findbugs/annotations -->
         <dependency>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-kms</artifactId>
-            <version>1.12.368</version>
+            <version>1.12.770</version>
         </dependency>
         <!-- AWS Java SDK v2 Dependencies -->
         <dependency>
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/src/main/java/software/amazon/cloudformation/proxy/StdCallbackContext.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/StdCallbackContext.java
@@ -151,8 +151,7 @@ public class StdCallbackContext {
                 }
                 return value;
             } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw new JsonMappingException(p, "Can not create empty map for class " + type + " @ " + p.getCurrentLocation(),
-                                               e);
+                throw new JsonMappingException(p, "Can not create empty map for class " + type + " @ " + p.currentLocation(), e);
             }
         }
 
@@ -237,8 +236,8 @@ public class StdCallbackContext {
                 } while (p.nextToken() != JsonToken.END_ARRAY);
                 return value;
             } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
-                throw new IOException("Can not create empty constructor collection class " + type + " @ "
-                    + p.getCurrentLocation(), e);
+                throw new IOException("Can not create empty constructor collection class " + type + " @ " + p.currentLocation(),
+                                      e);
             }
         }
     }

--- a/src/main/java/software/amazon/cloudformation/proxy/aws/SdkPojoDeserializer.java
+++ b/src/main/java/software/amazon/cloudformation/proxy/aws/SdkPojoDeserializer.java
@@ -82,7 +82,7 @@ public class SdkPojoDeserializer extends StdDeserializer<SdkPojo> {
              * if (next != JsonToken.FIELD_NAME) { throw new JsonMappingException(p,
              * "Expecting to get FIELD_NAME token, got " + next); }
              */
-            String fieldName = p.getCurrentName();
+            String fieldName = p.currentName();
             SdkField<?> sdkField = fieldMap.get(fieldName);
             if (sdkField == null) {
                 if (codec.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)) {
@@ -187,7 +187,7 @@ public class SdkPojoDeserializer extends StdDeserializer<SdkPojo> {
             if (p.currentToken() != JsonToken.FIELD_NAME) {
                 throw new JsonMappingException(p, "Expecting String key for map got " + p.currentToken());
             }
-            String fieldName = p.getCurrentName();
+            String fieldName = p.currentName();
             // progress to next token
             p.nextToken();
             value.put(fieldName, readObject(valueType, p, ctxt));
@@ -229,7 +229,7 @@ public class SdkPojoDeserializer extends StdDeserializer<SdkPojo> {
             case START_OBJECT:
                 MapBuilder builder = Document.mapBuilder();
                 while (p.nextToken() != JsonToken.END_OBJECT) {
-                    String fieldName = p.getCurrentName();
+                    String fieldName = p.currentName();
                     p.nextToken();
                     builder.putDocument(fieldName, readDocument(field, p, ctxt));
                 }

--- a/src/main/java/software/amazon/cloudformation/resource/Serializer.java
+++ b/src/main/java/software/amazon/cloudformation/resource/Serializer.java
@@ -53,7 +53,8 @@ public class Serializer {
     static {
         STRICT_OBJECT_MAPPER = JsonMapper.builder().configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true).build();
+            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+            .configure(com.fasterxml.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true).build();
         STRICT_OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         STRICT_OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
         STRICT_OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
@@ -74,7 +75,8 @@ public class Serializer {
     static {
         OBJECT_MAPPER = JsonMapper.builder().configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true).build();
+            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+            .configure(com.fasterxml.jackson.core.StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true).build();
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);


### PR DESCRIPTION
Bumps multiple dependencies to fix 18 CVEs (1 Critical, 10 High, 7 Medium) reported via Snyk scan against v2.2.4.

**Runtime dependency bumps:**
| Dependency | Old | New | CVEs Fixed |
|---|---|---|---|
| jackson-* | 2.14.1 | 2.17.2 | 4 High (DoS, buffer overflow, resource exhaustion) |
| commons-lang3 | 3.9 | 3.14.0 | 1 High (uncontrolled recursion) |
| aws-java-sdk-core | 1.12.367 | 1.12.770 | 1 High (ion-java resource exhaustion) |
| aws-java-sdk-sts/kms | 1.12.368 | 1.12.770 | aligned with core |
| aws-lambda-java-log4j2 | 1.5.1 | 1.6.0 | 2 High (encoding/escaping via log4j-core) |
| aws-encryption-sdk-java | 2.2.0 | 2.4.1 | 3 Medium (bouncycastle) |

**Build-time dependency bumps:**

| Dependency | Old | New | CVEs Fixed |
|---|---|---|---|
| spotless-maven-plugin | 2.28.0 | 2.40.0 | 2 High (jgit CVEs) |

## Jackson 2.17 compatibility
- Replaced deprecated `getCurrentLocation()` → `currentLocation()` and `getCurrentName()` → `currentName()`
- Re-enabled `StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` to preserve existing error message format

## Testing
- All 396 unit tests pass ✅
- `mvn verify` passes (compile + tests + spotbugs + checkstyle + spotless + jacoco)

Closes #438

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
