### PR TITLE
fix(ci): Update GitHub Actions to current versions

### DIFF
--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -13,11 +13,12 @@ jobs:
       AWS_REGION: us-east-1
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java & publishing credentials
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: '17'
+        distribution: 'corretto'
         server-id: sonatype-nexus-staging # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: SONATYPE_USERNAME # env variable for username in deploy
         server-password: SONATYPE_PASSWORD  # env variable for token in deploy

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -18,15 +18,16 @@ jobs:
         java: [17]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Set up Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'corretto'
     - name: Install python dependencies
       run: |
         pip install --upgrade 'attrs==19.2.0' wheel -r https://raw.githubusercontent.com/aws-cloudformation/cloudformation-cli/master/requirements.txt

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -10,11 +10,11 @@ jobs:
     if: endsWith(github.ref, '-plugin')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         pip install --upgrade wheel twine
@@ -22,6 +22,6 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI (If triggered from release)
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_KEY_CLOUDFORMATION_CLI_JAVA_PLUGIN  }}


### PR DESCRIPTION
actions/checkout v2 and actions/setup-java v1 are incompatible with the Node.js 24 runtime now enforced on GitHub Actions runners, causing the maven-release workflow to fail.

- actions/checkout: v2 → v4
- actions/setup-java: v1 → v4 (requires distribution field)
- actions/setup-python: v2 → v5
- pypa/gh-action-pypi-publish: @master → @release/v1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
