### PR TITLE
fix(ci): Update Sonatype OSSRH URL to Central Portal staging API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/service/local/</nexusUrl>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
The legacy aws.oss.sonatype.org endpoint has been shut down (OSSRH EOL June 2025). Update nexusUrl to use the Central Portal OSSRH Staging API compatibility shim at ossrh-staging-api.central.sonatype.com.

Note: GitHub secrets SONATYPE_USERNAME and SONATYPE_PASSWORD must be updated with a Central Portal user token generated at https://central.sonatype.com/account

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
