### PR TITLE
fix(ci): Remove /service/local/ suffix from nexusUrl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/service/local/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
The nexus-staging-maven-plugin appends /service/local/ internally. Providing the full path causes a validation error: 'Mandatory plugin parameter nexusUrl should be your Nexus base URL only'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
